### PR TITLE
[Backend] Only accept TESTMODE_REAL_DATA as true, when is it "yes"

### DIFF
--- a/backend/index.php
+++ b/backend/index.php
@@ -18,7 +18,9 @@ try {
     require_once "autoload.php";
 
 
-    $isPreparedForRealDataTest = getenv('TESTMODE_REAL_DATA', true) || getenv('TESTMODE_REAL_DATA');
+    $isPreparedForRealDataTest =
+        (getenv('TESTMODE_REAL_DATA', true) == 'yes') ||
+        (getenv('TESTMODE_REAL_DATA') == 'yes');
     $isTestModeRequested = isset($_SERVER['HTTP_TESTMODE']);
 
     if ($isTestModeRequested and $isPreparedForRealDataTest) {


### PR DESCRIPTION
The `TESTMODE_REAL_DATA-false`-statements in the docker-compose files will set it 'false' sometimes but this evaluated to true.