### PR TITLE
Rework documentation generation

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,231 +6,266 @@ variables:
 services:
  - docker:20.10-dind
 
-#stages:
-#  - build
-#  - test
-#  - deploy
+stages:
+  - build
+  - test
+  - deploy
 
-#.backend-change:
-#  rules:
-#    - changes:
-#      - backend/**/*
-#      - database/**/*
-#      - definitions/**/*
-#
-#.frontend-change:
-#  rules:
-#    - changes:
-#      - frontend/**/*
-#      - common/**/*
-#
-#.bs-change:
-#  rules:
-#    - changes:
-#      - broadcasting-service/**/*
-#      - common/**/*
+.backend-change:
+  rules:
+    - changes:
+      - backend/**/*
+      - database/**/*
+      - definitions/**/*
 
-#build-backend:
-#  stage: build
-#  rules:
-#    - !reference [.backend-change, rules]
-#    - if: $CI_PIPELINE_SOURCE == "external_pull_request_event" || $CI_PIPELINE_SOURCE == "web"
-#    - if: "$CI_COMMIT_TAG"
-#    - changes:
-#      - e2e/**/*
-#  script:
-#    - apk add make curl
-#    - curl -SL https://github.com/docker/compose/releases/download/v2.6.0/docker-compose-linux-x86_64 -o /usr/local/bin/docker-compose
-#    - chmod +x /usr/local/bin/docker-compose
-#    - make init
-#    - make build service=testcenter-backend
-#    - docker save iqbberlin/testcenter-backend > backend_image.tar
-#  artifacts:
-#    paths:
-#      - backend_image.tar
-#    expire_in: 30 minutes
-#
-#build-frontend:
-#  stage: build
-#  rules:
-#    - !reference [.frontend-change, rules]
-#    - if: $CI_PIPELINE_SOURCE == "external_pull_request_event" || $CI_PIPELINE_SOURCE == "web"
-#    - if: "$CI_COMMIT_TAG"
-#    - changes:
-#      - e2e/**/*
-#  script:
-#    - apk add make curl
-#    - curl -SL https://github.com/docker/compose/releases/download/v2.6.0/docker-compose-linux-x86_64 -o /usr/local/bin/docker-compose
-#    - chmod +x /usr/local/bin/docker-compose
-#    - make init
-#    - make build service=testcenter-frontend
-#    - docker save iqbberlin/testcenter-frontend > frontend_image.tar
-#  artifacts:
-#    paths:
-#      - frontend_image.tar
-#    expire_in: 30 minutes
-#
-#build-broadcasting-service:
-#  stage: build
-#  rules:
-#    - !reference [.bs-change, rules]
-#    - if: $CI_PIPELINE_SOURCE == "external_pull_request_event" || $CI_PIPELINE_SOURCE == "web"
-#    - if: "$CI_COMMIT_TAG"
-#    - changes:
-#        - e2e/**/*
-#  script:
-#    - apk add make curl
-#    - curl -SL https://github.com/docker/compose/releases/download/v2.6.0/docker-compose-linux-x86_64 -o /usr/local/bin/docker-compose
-#    - chmod +x /usr/local/bin/docker-compose
-#    - make init
-#    - make build service=testcenter-broadcasting-service
-#    - docker save iqbberlin/testcenter-broadcasting-service > bs_image.tar
-#  artifacts:
-#    paths:
-#      - bs_image.tar
-#    expire_in: 30 minutes
-#
-#test-backend-unit:
-#  stage: test
-#  rules:
-#    - !reference [.backend-change, rules]
-#    - if: $CI_PIPELINE_SOURCE == "external_pull_request_event" || $CI_PIPELINE_SOURCE == "web"
-#    - if: "$CI_COMMIT_TAG"
-#  needs:
-#    - job: build-backend
-#      artifacts: true
-#  script:
-#    - apk add make docker-compose
-#    - make init
-#    - docker load -i backend_image.tar
-#    - make test-backend-unit
-#
-#test-frontend-unit:
-#  stage: test
-#  rules:
-#    - !reference [.frontend-change, rules]
-#    - if: $CI_PIPELINE_SOURCE == "external_pull_request_event" || $CI_PIPELINE_SOURCE == "web"
-#    - if: "$CI_COMMIT_TAG"
-#  needs:
-#    - job: build-frontend
-#      artifacts: true
-#  script:
-#    - apk add make docker-compose
-#    - make init-env
-#    - make init-frontend
-#    - docker load -i frontend_image.tar
-#    - make test-frontend-unit
-#
-#test-broadcasting-service-unit:
-#  stage: test
-#  rules:
-#    - !reference [.bs-change, rules]
-#    - if: "$CI_COMMIT_TAG"
-#  needs:
-#    - job: build-broadcasting-service
-#      artifacts: true
-#  script:
-#    - apk add make docker-compose
-#    - make init-env
-#    - docker load -i bs_image.tar
-#    - make test-broadcasting-service-unit
-#
-#test-e2e:
-#  stage: test
-#  rules:
-#    - if: $CI_PIPELINE_SOURCE == "external_pull_request_event" || $CI_PIPELINE_SOURCE == "web"
-#    - if: "$CI_COMMIT_TAG"
-#    - changes:
-#      - e2e/**/*
-#  needs:
-#    - job: build-frontend
-#      artifacts: true
-#    - job: build-backend
-#      artifacts: true
-#    - job: build-broadcasting-service
-#      artifacts: true
-#  script:
-#    - apk add make
-#    - docker load -i frontend_image.tar
-#    - docker load -i backend_image.tar
-#    - docker load -i bs_image.tar
-#    - make test-system-headless
-#  artifacts:
-#    when: always
-#    paths:
-#      - /app/cypress/videos/**/*.mp4
-#      - /app/cypress/screenshots/**/*.png
-#    expire_in: 1 day
-#
-#test-backend-api:
-#  stage: test
-#  rules:
-#    - !reference [.backend-change, rules]
-#    - if: $CI_PIPELINE_SOURCE == "external_pull_request_event" || $CI_PIPELINE_SOURCE == "web"
-#    - if: "$CI_COMMIT_TAG"
-#  needs:
-#    - job: build-backend
-#      artifacts: true
-#  script:
-#    - apk add make
-#    - make init
-#    - docker load -i backend_image.tar
-#    - make test-backend-api
-#
-#test-backend-api-mysql:
-#  stage: test
-#  rules:
-#    - if: "$CI_COMMIT_TAG"
-#  needs:
-#    - job: build-backend
-#      artifacts: true
-#  script:
-#    - apk add make
-#    - make init
-#    - docker load -i backend_image.tar
-#    - make test-backend-api-mysql
-#
-#test-backend-initialization:
-#  stage: test
-#  rules:
-#    - if: $CI_PIPELINE_SOURCE == "external_pull_request_event" || $CI_PIPELINE_SOURCE == "web"
-#    - if: "$CI_COMMIT_TAG"
-#  needs:
-#    - job: build-backend
-#      artifacts: true
-#  script:
-#    - apk add make
-#    - make init
-#    - make test-backend-initialization-general
-#
-#deploy-tagged-docker-image:
-#  stage: deploy
-#  rules:
-#    - if: "$CI_COMMIT_TAG"
-#  script:
-#    - apk add make curl
-#    - curl -SL https://github.com/docker/compose/releases/download/v2.6.0/docker-compose-linux-x86_64 -o /usr/local/bin/docker-compose
-#    - chmod +x /usr/local/bin/docker-compose
-#    - make init
-#    - docker build --target prod -t iqbberlin/testcenter-backend:$CI_COMMIT_TAG -f docker/backend.Dockerfile .
-#    - docker build --target prod -t iqbberlin/testcenter-frontend:$CI_COMMIT_TAG -f docker/frontend.Dockerfile .
-#    - docker build --target prod -t iqbberlin/testcenter-broadcasting-service:$CI_COMMIT_TAG -f docker/broadcasting-service.Dockerfile .
-#    - echo "$DOCKERHUB_PASSWORD" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
-#    - docker push iqbberlin/testcenter-backend:$CI_COMMIT_TAG
-#    - docker push iqbberlin/testcenter-frontend:$CI_COMMIT_TAG
-#    - docker push iqbberlin/testcenter-broadcasting-service:$CI_COMMIT_TAG
+.frontend-change:
+  rules:
+    - changes:
+      - frontend/**/*
+      - common/**/*
+
+.bs-change:
+  rules:
+    - changes:
+      - broadcasting-service/**/*
+      - common/**/*
+
+build-backend:
+  stage: build
+  rules:
+    - !reference [.backend-change, rules]
+    - if: $CI_PIPELINE_SOURCE == "external_pull_request_event" || $CI_PIPELINE_SOURCE == "web"
+    - if: "$CI_COMMIT_TAG"
+    - changes:
+      - e2e/**/*
+  script:
+    - apk add make curl
+    - curl -SL https://github.com/docker/compose/releases/download/v2.6.0/docker-compose-linux-x86_64 -o /usr/local/bin/docker-compose
+    - chmod +x /usr/local/bin/docker-compose
+    - make init
+    - make build service=testcenter-backend
+    - docker save iqbberlin/testcenter-backend > backend_image.tar
+  artifacts:
+    paths:
+      - backend_image.tar
+    expire_in: 30 minutes
+
+build-frontend:
+  stage: build
+  rules:
+    - !reference [.frontend-change, rules]
+    - if: $CI_PIPELINE_SOURCE == "external_pull_request_event" || $CI_PIPELINE_SOURCE == "web"
+    - if: "$CI_COMMIT_TAG"
+    - changes:
+      - e2e/**/*
+  script:
+    - apk add make curl
+    - curl -SL https://github.com/docker/compose/releases/download/v2.6.0/docker-compose-linux-x86_64 -o /usr/local/bin/docker-compose
+    - chmod +x /usr/local/bin/docker-compose
+    - make init
+    - make build service=testcenter-frontend
+    - docker save iqbberlin/testcenter-frontend > frontend_image.tar
+  artifacts:
+    paths:
+      - frontend_image.tar
+    expire_in: 30 minutes
+
+build-broadcasting-service:
+  stage: build
+  rules:
+    - !reference [.bs-change, rules]
+    - if: $CI_PIPELINE_SOURCE == "external_pull_request_event" || $CI_PIPELINE_SOURCE == "web"
+    - if: "$CI_COMMIT_TAG"
+    - changes:
+        - e2e/**/*
+  script:
+    - apk add make curl
+    - curl -SL https://github.com/docker/compose/releases/download/v2.6.0/docker-compose-linux-x86_64 -o /usr/local/bin/docker-compose
+    - chmod +x /usr/local/bin/docker-compose
+    - make init
+    - make build service=testcenter-broadcasting-service
+    - docker save iqbberlin/testcenter-broadcasting-service > bs_image.tar
+  artifacts:
+    paths:
+      - bs_image.tar
+    expire_in: 30 minutes
+
+test-backend-unit:
+  stage: test
+  rules:
+    - !reference [.backend-change, rules]
+    - if: $CI_PIPELINE_SOURCE == "external_pull_request_event" || $CI_PIPELINE_SOURCE == "web"
+    - if: "$CI_COMMIT_TAG"
+  needs:
+    - job: build-backend
+      artifacts: true
+  script:
+    - apk add make docker-compose
+    - make init
+    - docker load -i backend_image.tar
+    - make test-backend-unit-coverage
+  artifacts:
+    paths:
+      - docs/dist/test-coverage-backend-unit/*
+    expire_in: 30 minutes
+
+test-frontend-unit:
+  stage: test
+  rules:
+    - !reference [.frontend-change, rules]
+    - if: $CI_PIPELINE_SOURCE == "external_pull_request_event" || $CI_PIPELINE_SOURCE == "web"
+    - if: "$CI_COMMIT_TAG"
+  needs:
+    - job: build-frontend
+      artifacts: true
+  script:
+    - apk add make docker-compose
+    - make init-env
+    - make init-frontend
+    - docker load -i frontend_image.tar
+    - make test-frontend-unit-coverage
+  artifacts:
+    paths:
+      - docs/dist/test-coverage-frontend-unit/*
+    expire_in: 30 minutes
+
+test-broadcasting-service-unit:
+  stage: test
+  rules:
+    - !reference [.bs-change, rules]
+    - if: "$CI_COMMIT_TAG"
+  needs:
+    - job: build-broadcasting-service
+      artifacts: true
+  script:
+    - apk add make docker-compose
+    - make init-env
+    - docker load -i bs_image.tar
+    - make test-broadcasting-service-unit-coverage
+  artifacts:
+    paths:
+      - docs/dist/test-coverage-broadcasting-service-unit/*
+    expire_in: 30 minutes
+
+test-e2e:
+  stage: test
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "external_pull_request_event" || $CI_PIPELINE_SOURCE == "web"
+    - if: "$CI_COMMIT_TAG"
+    - changes:
+      - e2e/**/*
+  needs:
+    - job: build-frontend
+      artifacts: true
+    - job: build-backend
+      artifacts: true
+    - job: build-broadcasting-service
+      artifacts: true
+  script:
+    - apk add make
+    - docker load -i frontend_image.tar
+    - docker load -i backend_image.tar
+    - docker load -i bs_image.tar
+    - make test-system-headless
+  artifacts:
+    when: always
+    paths:
+      - e2e/cypress/videos/**/*.mp4
+      - e2e/cypress/screenshots/**/*.png
+    expire_in: 30 minutes
+
+test-backend-api:
+  stage: test
+  rules:
+    - !reference [.backend-change, rules]
+    - if: $CI_PIPELINE_SOURCE == "external_pull_request_event" || $CI_PIPELINE_SOURCE == "web"
+    - if: "$CI_COMMIT_TAG"
+  needs:
+    - job: build-backend
+      artifacts: true
+  script:
+    - apk add make
+    - make init
+    - docker load -i backend_image.tar
+    - make test-backend-api
+
+test-backend-api-mysql:
+  stage: test
+  rules:
+    - if: "$CI_COMMIT_TAG"
+  needs:
+    - job: build-backend
+      artifacts: true
+  script:
+    - apk add make
+    - make init
+    - docker load -i backend_image.tar
+    - make test-backend-api-mysql
+
+test-backend-initialization:
+  stage: test
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "external_pull_request_event" || $CI_PIPELINE_SOURCE == "web"
+    - if: "$CI_COMMIT_TAG"
+  needs:
+    - job: build-backend
+      artifacts: true
+  script:
+    - apk add make
+    - make init
+    - make test-backend-initialization-general
+
+deploy-tagged-docker-image:
+  stage: deploy
+  rules:
+    - if: "$CI_COMMIT_TAG"
+  script:
+    - apk add make curl
+    - curl -SL https://github.com/docker/compose/releases/download/v2.6.0/docker-compose-linux-x86_64 -o /usr/local/bin/docker-compose
+    - chmod +x /usr/local/bin/docker-compose
+    - make init
+    - docker build --target prod -t iqbberlin/testcenter-backend:$CI_COMMIT_TAG -f docker/backend.Dockerfile .
+    - docker build --target prod -t iqbberlin/testcenter-frontend:$CI_COMMIT_TAG -f docker/frontend.Dockerfile .
+    - docker build --target prod -t iqbberlin/testcenter-broadcasting-service:$CI_COMMIT_TAG -f docker/broadcasting-service.Dockerfile .
+    - echo "$DOCKERHUB_PASSWORD" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
+    - docker push iqbberlin/testcenter-backend:$CI_COMMIT_TAG
+    - docker push iqbberlin/testcenter-frontend:$CI_COMMIT_TAG
+    - docker push iqbberlin/testcenter-broadcasting-service:$CI_COMMIT_TAG
+
+generate-docs:
+  stage: build
+  rules:
+    - if: "$CI_COMMIT_TAG"
+  script:
+    - apk add make docker-compose
+    - make init
+    - make update-docs
+  artifacts:
+    paths:
+      - docs/dist/compodoc-frontend/*
+      - docs/dist/compodoc-broadcasting-service/*
+    expire_in: 30 minutes
 
 pages:
   stage: deploy
+  rules:
+    - if: "$CI_COMMIT_TAG"
+  needs:
+    - job: test-backend-unit
+      artifacts: true
+    - job: test-frontend-unit
+      artifacts: true
+    - job: test-broadcasting-service-unit
+      artifacts: true
+    - job: generate-docs
+      artifacts: true
   image: ruby:latest
   script:
     - mkdir public
     - cd docs
-    - gem install bundler jekyll
+    - gem install bundler
     - bundle install
     - jekyll build -d ../public
   artifacts:
     paths:
       - public
-#  rules:
-#    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,7 @@
+---
+layout: default
+---
+
 # Changelog & Upgrade Information
 
 ## 13.0.0-alpha

--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -2,8 +2,6 @@
 
 source "http://rubygems.org"
 
-gem "jekyll"
-
+gem "jekyll", "~> 4.2.2"
 gem "webrick", "~> 1.7"
-
-gem "jekyll-theme-minimal"
+gem "minima", "~> 2.5"

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -29,13 +29,12 @@ GEM
       rouge (~> 3.0)
       safe_yaml (~> 1.0)
       terminal-table (~> 2.0)
+    jekyll-feed (0.16.0)
+      jekyll (>= 3.7, < 5.0)
     jekyll-sass-converter (2.2.0)
       sassc (> 2.0.1, < 3.0)
     jekyll-seo-tag (2.8.0)
       jekyll (>= 3.8, < 5.0)
-    jekyll-theme-minimal (0.2.0)
-      jekyll (> 3.5, < 5.0)
-      jekyll-seo-tag (~> 2.0)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
     kramdown (2.4.0)
@@ -47,6 +46,10 @@ GEM
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     mercenary (0.4.0)
+    minima (2.5.1)
+      jekyll (>= 3.5, < 5.0)
+      jekyll-feed (~> 0.9)
+      jekyll-seo-tag (~> 2.1)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
     public_suffix (5.0.0)
@@ -67,8 +70,8 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  jekyll
-  jekyll-theme-minimal
+  jekyll (~> 4.2.2)
+  minima (~> 2.5)
   webrick (~> 1.7)
 
 BUNDLED WITH

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,1 +1,40 @@
-theme: jekyll-theme-minimal
+# Site settings
+# These are used to personalize your new site. If you look in the HTML files,
+# you will see them accessed via {{ site.title }}, {{ site.email }}, and so on.
+# You can create any custom variable you would like, and they will be accessible
+# in the templates via {{ site.myvariable }}.
+
+title: Testcenter Dokumentation
+email: mechtel@iqb.hu-berlin.de
+description: >- # this means to ignore newlines until "baseurl:"
+  IQB-Testcenter Beschreibungstext... TODO
+baseurl: "/iqb/testcenter" # the subpath of your site, e.g. /blog
+url: "https://pages.cms.hu-berlin.de" # the base hostname & protocol for your site, e.g. http://example.com
+
+# Build settings
+theme: minima
+
+include:
+  - _css
+  - _icons
+  - _js
+
+# Exclude from processing.
+# The following items will not be processed, by default.
+# Any item listed under the `exclude:` key here will be automatically added to
+# the internal "default list".
+#
+# Excluded items can be processed by explicitly listing the directories or
+# their entries' file path in the `include:` list.
+#
+# exclude:
+#   - .sass-cache/
+#   - .jekyll-cache/
+#   - gemfiles/
+#   - Gemfile
+#   - Gemfile.lock
+#   - node_modules/
+#   - vendor/bundle/
+#   - vendor/cache/
+#   - vendor/gems/
+#   - vendor/ruby/

--- a/docs/dist/booklet-config.md
+++ b/docs/dist/booklet-config.md
@@ -1,3 +1,7 @@
+---
+layout: default
+---
+
 # Booklet config
 There are some configuration parameters for adjusting the behaviour during the test.This 
 document describes the ways to bring the parameters to the application and lists

--- a/docs/dist/custom-texts.md
+++ b/docs/dist/custom-texts.md
@@ -1,3 +1,7 @@
+---
+layout: default
+---
+
 # CustomTexts
 This application enables changes of texts during runtime. It's an implementation 
 of the CustomTextPipe/CustomTextService 

--- a/docs/dist/developer-guide.md
+++ b/docs/dist/developer-guide.md
@@ -1,3 +1,7 @@
+---
+layout: default
+---
+
 # Developer's Guide
 
 ## Application structure

--- a/docs/dist/installation-dev.md
+++ b/docs/dist/installation-dev.md
@@ -1,3 +1,7 @@
+---
+layout: default
+---
+
 # Installation for development
 
 The other way of installation gives you more options to access data, logs, to change settings more in 

--- a/docs/dist/installation-local.md
+++ b/docs/dist/installation-local.md
@@ -1,4 +1,6 @@
-TODO TODO TODO
+---
+layout: default
+---
 
 # Requirements
 * npm 8

--- a/docs/dist/installation-prod.md
+++ b/docs/dist/installation-prod.md
@@ -1,3 +1,7 @@
+---
+layout: default
+---
+
 # Installation for production
 
 "Production" here means that you just want to install and use the application, not more. You do not like to get a look behind the curtain or to run sophisticated performance analyses. This type of installation has fewer requirements in regard of software and space.

--- a/docs/dist/server-setup.md
+++ b/docs/dist/server-setup.md
@@ -1,3 +1,7 @@
+---
+layout: default
+---
+
 # More server setup and handling
 
 ## SSL

--- a/docs/dist/test-mode.md
+++ b/docs/dist/test-mode.md
@@ -1,3 +1,7 @@
+---
+layout: default
+---
+
 # Modes for test execution
 
 For the test or the survey, all execution parameters are given by

--- a/docs/dist/trouble-shooting.md
+++ b/docs/dist/trouble-shooting.md
@@ -1,3 +1,7 @@
+---
+layout: default
+---
+
 ## Trouble Shooting
 
 ### Timeouts when building fresh images

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,9 +1,6 @@
 ---
+layout: default
 ---
-
-**This is the next-generation repository of Testcenter which is not in charge right now. Until it's ready please 
-refer to https://github.com/iqb-berlin/testcenter-setup.**
-
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![(CI Status)](https://scm.cms.hu-berlin.de/iqb/testcenter-setup/badges/master/pipeline.svg)](https://scm.cms.hu-berlin.de/iqb/testcenter)
 ![GitHub tag (latest SemVer)](https://img.shields.io/github/v/tag/iqb-berlin/testcenter)
@@ -14,45 +11,39 @@ The IQB-Testcenter is a web application for technology based accessed and survey
 [the Institute for Educational Quality Improvement (IQB)](https://www.iqb.hu-berlin.de/) in Berlin, Germany.
 
 ## For Users
-
 * **[User's Manual](https://github.com/iqb-berlin/iqb-berlin.github.io/wiki/2-Testcenter)** (in german)
 * [Bug Reports](https://github.com/iqb-berlin/testcenter/issues)
-* [Changelog](https://github.com/iqb-berlin/testcenter-frontend/blob/master/CHANGELOG.md)
+* [Changelog]({% link CHANGELOG.md %})
 
 ### Special docs 
-* [Overview about super-states of running sessions and their icons](https://iqb-berlin.github.io/testcenter/dist/test-session-super-states.html)
-* [List of modes of test-execution](https://iqb-berlin.github.io/testcenter/dist/test-mode)
-* [Parameters of booklet-configuration](https://iqb-berlin.github.io/testcenter/dist/booklet-config)
-* [Customizable Labels in the UI](https://iqb-berlin.github.io/testcenter/dist/custom-texts)
+* [Overview about super-states of running sessions and their icons]({% link dist/test-session-super-states.html %})
+* [List of modes of test-execution]({% link dist/test-mode.md %})
+* [Parameters of booklet-configuration]({% link dist/booklet-config.md %})
+* [Customizable Labels in the UI]({% link dist/custom-texts.md %})
 
 ## For Hosters
-
-* **[Installation and Update](https://iqb-berlin.github.io/testcenter/dist/installation-prod)**
-* [Server Configuration](https://iqb-berlin.github.io/testcenter/dist/server-setup)
-* [Trouble Shooting](https://iqb-berlin.github.io/testcenter/dist/trouble-shooting)
+* **[Installation and Update]({% link dist/installation-prod.md %})**
+* [Server Configuration]({% link dist/server-setup.md %})
+* [Trouble Shooting]({% link dist/trouble-shooting.md %})
 
 ## For Developers
-
-* **[Installation for Development](https://iqb-berlin.github.io/testcenter/dist/installation-dev)**
-* **[Developer's Guide](https://iqb-berlin.github.io/testcenter/dist/developer-guide)**
+* **[Installation for Development]({% link dist/installation-dev.md %})**
+* **[Developer's Guide]({% link dist/developer-guide.md %})**
 
 ### API Documentation
-
-* [HTTP API Backend](https://iqb-berlin.github.io/testcenter/dist/api/index.html)
+* [HTTP API Backend]({% link dist/api/index.html %})
 * [Verona Player API](https://verona-interfaces.github.io/player/)
 
 ### Compodoc Documentation
-
-* [Frontend](https://iqb-berlin.github.io/testcenter/dist/compodoc-frontend/index.html)
-* [Broadcasting-Service](https://iqb-berlin.github.io/testcenter/dist/compodoc-broadcasting-service/index.html)
+* [Frontend]({% link dist/compodoc-frontend/index.html %})
+* [Broadcasting-Service]({% link dist/compodoc-broadcasting-service/index.html %})
 
 ### Test Coverage
-
-* [Backend by Unit-Tests](https://iqb-berlin.github.io/testcenter/dist/test-coverage-backend-unit/index.html)
-* [Frontend by Unit-Tests](https://iqb-berlin.github.io/testcenter/dist/test-coverage-frontend-unit/report/index.html)
-* [Broadcasting-Service by Unit-Tets](https://iqb-berlin.github.io/testcenter/dist/test-coverage-broadcasting-service-unit/lcov-report/index.html)
-* [Frontend by System-Tests](https://iqb-berlin.github.io/testcenter/dist/test-coverage-frontend-system/report/index.html)
+* [Backend by Unit-Tests]({% link dist/test-coverage-backend-unit/index.html %})
+* [Frontend by Unit-Tests]({% link dist/test-coverage-frontend-unit/report/index.html %})
+* [Broadcasting-Service by Unit-Tets]({% link dist/test-coverage-broadcasting-service-unit/lcov-report/index.html %})
+* [Frontend by System-Tests]({% link dist/test-coverage-frontend-system/lcov-report/index.html %})
 
 ### Misc
-* [Install and run without docker](https://iqb-berlin.github.io/testcenter/dist/installation-local)
+* [Install and run without docker]({% link dist/installation-local.md %})
 


### PR DESCRIPTION
Add GitLab-Pages job to CI pipeline. This takes all the generated  documentation and test coverage reports of previous steps and publishes  them to GitLab-Pages using Jekyll.
E2E coverage is still missing.

The Markdown documents need the 3-dashes prefix for Jekyll to transform  them to HTML.