### PR TITLE
[frontend] Improve Settings component layout

### DIFF
--- a/frontend/src/app/superadmin/settings/settings.component.ts
+++ b/frontend/src/app/superadmin/settings/settings.component.ts
@@ -3,24 +3,24 @@ import { Component } from '@angular/core';
 @Component({
   template: `
     <div fxLayout="column" fxLayoutAlign="start stretch" class="admin-tab-content">
-      <div fxLayout="row" class="div-row">
-        <div fxFlex="30">
+      <div fxLayout="row" class="settings-group">
+        <div fxFlex="20">
           <mat-label>Text-Ersetzungen</mat-label>
         </div>
-        <div fxFlex="68">
+        <div fxFlex="78">
           <app-custom-texts></app-custom-texts>
         </div>
       </div>
-      <div fxLayout="row" class="div-row">
-        <div fxFlex="30">
+      <div fxLayout="row" class="settings-group">
+        <div fxFlex="20">
           <mat-label>Konfiguration der Anwendung</mat-label>
         </div>
-        <div fxFlex="68">
+        <div fxFlex="78">
           <app-app-config></app-app-config>
         </div>
       </div>
     </div>
   `,
-  styles: ['.div-row {border-color: gray; border-width: 0 0 1px 0; border-style: solid; margin-top: 10px}']
+  styles: ['.settings-group {margin-top: 10px;}']
 })
 export class SettingsComponent {}

--- a/frontend/src/app/superadmin/settings/settings.component.ts
+++ b/frontend/src/app/superadmin/settings/settings.component.ts
@@ -2,7 +2,7 @@ import { Component } from '@angular/core';
 
 @Component({
   template: `
-    <div fxLayout="column" fxLayoutAlign="start stretch" class="admin-tab-content">
+    <div fxLayout="column" fxLayoutAlign="start stretch">
       <div fxLayout="row" class="settings-group">
         <div fxFlex="20">
           <mat-label>Text-Ersetzungen</mat-label>


### PR DESCRIPTION
- Border around settings group removed. It served no purpose and was  misaligned.
- Give the settings column more width.
- Give descriptive name to css class

Vorher:
![vorher](https://user-images.githubusercontent.com/446878/199608837-d0798566-7855-415d-8df4-c4ff10a4425c.png)

Nachher:
![nachher](https://user-images.githubusercontent.com/446878/199608854-c59bc5e5-6088-4ae5-ad5a-578722bdd2b3.png)
