### PR TITLE
Fix/system check report

### DIFF
--- a/frontend/src/app/sys-check/report/report.component.ts
+++ b/frontend/src/app/sys-check/report/report.component.ts
@@ -81,8 +81,4 @@ export class ReportComponent implements OnInit {
     });
   }
 
-  ngOnDestroy() : void {
-    this.ds.questionnaireReport.length = 0;
-    
-  }
 }

--- a/frontend/src/app/sys-check/report/report.component.ts
+++ b/frontend/src/app/sys-check/report/report.component.ts
@@ -62,6 +62,7 @@ export class ReportComponent implements OnInit {
       this.questionnaireDataWarnings = [];
       if (this.ds.checkConfig && this.ds.checkConfig.questions.length > 0) {
         if (this.ds.questionnaireReport.length > 0) {
+          console.log(this.ds.questionnaireReport)
           this.ds.questionnaireReport.forEach(re => {
             if (re.warning) {
               this.questionnaireDataWarnings.push(re);
@@ -78,5 +79,10 @@ export class ReportComponent implements OnInit {
         }
       }
     });
+  }
+
+  ngOnDestroy() : void {
+    this.ds.questionnaireReport.length = 0;
+    
   }
 }

--- a/frontend/src/app/sys-check/welcome/welcome.component.ts
+++ b/frontend/src/app/sys-check/welcome/welcome.component.ts
@@ -42,6 +42,7 @@ export class WelcomeComponent implements OnInit {
       this.getNavigatorInfo();
       this.getBrowserPluginInfo();
       this.getBrowserRating();
+      this.ds.questionnaireReport.length = 0;
       this.getTime()
         .subscribe(() => {
           const report = Array.from(this.report.values())


### PR DESCRIPTION
Die Veränderungen beziehen sich auf das Ticket # 116.
Gegebene Antworten des Fragebogens werden jetzt immer dann resettet, wenn man auf der Willkommensseite('/w') eines Systemchecks ist.
Allerdings führt das auch dazu, dass man die Antworten ausversehen zurücksetzen kann, wenn man mit den prev/next Navigationsbuttons bis zurück zur Willkommensseite navigiert. Das sollte aber eigentlich nicht so oft passieren
Ist das so in Ordnung oder soll das lieber anders geregelt werden?
Ich hatte es alternativ mit ngOnDestroy() beim report component probiert, aber das führte immer dazu, dass zurückblättern im Syscheck die Antworten resetten würde.