### PR TITLE
Syscheck questionare header value from textnode

### DIFF
--- a/frontend/src/app/sys-check/questionnaire/questionnaire.component.html
+++ b/frontend/src/app/sys-check/questionnaire/questionnaire.component.html
@@ -11,7 +11,7 @@
           <div [formGroup]="form" class="formList" fxLayout="column" *ngIf="form">
             <div *ngFor="let q of ds.checkConfig?.questions">
               <div [ngSwitch]="q.type" class="formEntry" fxLayout="column" fxLayoutGap="5px">
-                <h3 *ngSwitchCase="'header'">{{ q.prompt }}{{ q.value }}</h3>
+                <h3 *ngSwitchCase="'header'">{{ q.options.length > 0 ? q.options : q.prompt }}</h3>
                 <mat-form-field *ngSwitchCase="'text'">
                   <p>{{q.prompt}}</p>
                   <textarea matInput data-cy="textarea" [formControlName]="q.id" [id]="q.id" cdkTextareaAutosize cdkAutosizeMinRows="2" class="formEntry"></textarea>


### PR DESCRIPTION
Die SysCheck questionaire header bekommen ihren Wert jetzt vorzugsweise vom value/textnode.
<Q id="1" type="header" prompt="Fragebogen zum Systemcheck 1">Value vom Header</Q>
In diesem Beispiel also "Value vom Header". Ist dieser nicht vorhanden, wird zurück auf den prompt gegriffen.

Der Wert des value/textnodes wird im Moment unter q.options gespeichert, ist das so gewollt? Ich hätte erwartet, dass man das unter q.value finden würde.