### PR TITLE
Enhancement/frontend tlk as custom text

### DIFF
--- a/definitions/custom-texts.json
+++ b/definitions/custom-texts.json
@@ -283,7 +283,7 @@
     "label" : "Der 'Immer alle Auswählen'-Schalter",
     "defaultvalue" : "Alle Tests gleichzeitig steuern"
   },
-  "gm_tlk_selection_text": {
+  "gm_selection_text": {
     "label" : "Der Text im Button bei Auswahl der Testleitungskonsole",
     "defaultvalue" : "Überwachung starten"
   }

--- a/definitions/custom-texts.json
+++ b/definitions/custom-texts.json
@@ -282,5 +282,9 @@
   "gm_auto_checkall" : {
     "label" : "Der 'Immer alle Auswählen'-Schalter",
     "defaultvalue" : "Alle Tests gleichzeitig steuern"
+  },
+  "gm_tlk_selection_text": {
+    "label" : "Der Text im Button bei Auswahl der Testleitungskonsole",
+    "defaultvalue" : "Überwachung starten"
   }
 }

--- a/frontend/src/app/app-root/monitor-starter/monitor-starter.component.html
+++ b/frontend/src/app/app-root/monitor-starter/monitor-starter.component.html
@@ -17,7 +17,7 @@
           *ngFor="let accessObject of accessObjects.testGroupMonitor"
         >
           <span class="booklet_title">{{accessObject.label}}</span>
-          <span class="booklet_status">{{'Überwachung starten' | customtext: 'tlk-text' | async}}</span>
+          <span class="booklet_status">{{'gm_tlk_selection_text' | customtext: 'gm_tlk_selection_text' | async}}</span>
         </button>
 
         <ng-container *ngIf="accessObjects.attachmentManager && accessObjects.attachmentManager.length">

--- a/frontend/src/app/app-root/monitor-starter/monitor-starter.component.html
+++ b/frontend/src/app/app-root/monitor-starter/monitor-starter.component.html
@@ -17,7 +17,7 @@
           *ngFor="let accessObject of accessObjects.testGroupMonitor"
         >
           <span class="booklet_title">{{accessObject.label}}</span>
-          <span class="booklet_status">{{'gm_tlk_selection_text' | customtext: 'gm_tlk_selection_text' | async}}</span>
+          <span class="booklet_status">{{'gm_selection_text' | customtext: 'gm_selection_text' | async}}</span>
         </button>
 
         <ng-container *ngIf="accessObjects.attachmentManager && accessObjects.attachmentManager.length">

--- a/frontend/src/app/app-root/monitor-starter/monitor-starter.component.html
+++ b/frontend/src/app/app-root/monitor-starter/monitor-starter.component.html
@@ -17,7 +17,7 @@
           *ngFor="let accessObject of accessObjects.testGroupMonitor"
         >
           <span class="booklet_title">{{accessObject.label}}</span>
-          <span class="booklet_status">Überwachung starten</span>
+          <span class="booklet_status">{{'Überwachung starten' | customtext: 'tlk-text' | async}}</span>
         </button>
 
         <ng-container *ngIf="accessObjects.attachmentManager && accessObjects.attachmentManager.length">


### PR DESCRIPTION
Wie in #62 gewünscht ist der Text im Button nun als customText angelegt.
Dieser trägt den Key: gm_tlk_selection_text
Ich habe ebenfalls label und default value in der custom-text.json angelegt.
Der default value ist: Überwachung starten