### PR TITLE
Re-enable customTexts for booklets

### DIFF
--- a/backend/test/unit/files/XMLFileTest.php
+++ b/backend/test/unit/files/XMLFileTest.php
@@ -139,6 +139,6 @@ class XMLFileTest extends TestCase {
         $this->assertEquals(85, $xf->getSize());
         $this->assertEquals('Booklet', $xf->getRoottagName());
         $this->assertEquals('', $xf->getDescription());
-        $this->assertEquals("[error] Error [1871] in line 1: Element 'Invalid': This element is not expected. Expected is one of ( BookletConfig, Units ).", $xf->getErrorString());
+        $this->assertEquals("[error] Error [1871] in line 1: Element 'Invalid': This element is not expected. Expected is one of ( CustomTexts, BookletConfig, Units ).", $xf->getErrorString());
     }
 }

--- a/definitions/vo_Booklet.xsd
+++ b/definitions/vo_Booklet.xsd
@@ -15,6 +15,14 @@
           </xs:complexType>
         </xs:element>
 
+        <xs:element name="CustomTexts" minOccurs="0">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="CustomText" type="customTextType" maxOccurs="unbounded"/>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+
         <xs:element name="BookletConfig" minOccurs="0">
           <xs:complexType>
             <xs:sequence>
@@ -120,6 +128,14 @@
     <xs:simpleContent>
       <xs:extension base="xs:string">
         <xs:attribute name="key" type="xs:ID" use="required" />
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:complexType name="customTextType">
+    <xs:simpleContent>
+      <xs:extension base="xs:string">
+        <xs:attribute name="key" type="xs:ID" use="required"/>
       </xs:extension>
     </xs:simpleContent>
   </xs:complexType>

--- a/frontend/src/app/test-controller/services/test-loader.service.ts
+++ b/frontend/src/app/test-controller/services/test-loader.service.ts
@@ -293,7 +293,7 @@ export class TestLoaderService {
         const customTexts = TestLoaderService.getChildElements(customTextsElements[0]);
         const customTextsForBooklet = {};
         for (let childIndex = 0; childIndex < customTexts.length; childIndex++) {
-          if (customTexts[childIndex].nodeName === 'Text') {
+          if (customTexts[childIndex].nodeName === 'CustomText') {
             const customTextKey = customTexts[childIndex].getAttribute('key');
             if ((typeof customTextKey !== 'undefined') && (customTextKey !== null)) {
               customTextsForBooklet[customTextKey] = customTexts[childIndex].textContent;


### PR DESCRIPTION
Resolves #58 
Dieser Pull Request beinhaltet folgende Änderungen:
Update für die Booklet xsd damit CustomTexts wieder erlaubt sind
Ein Update für einen Test im Backend, der mit dem Update der Booklet XSD zutun hat
Ein korrigieren einer If-Abfrage die dazu geführt hat, dass Customtext in Booklets nicht korrekt angezeigt wurden