### PR TITLE
Add container-scanning to CI pipeline

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -208,22 +208,80 @@ test-backend-initialization:
     - make init
     - make test-backend-initialization-general
 
-deploy-tagged-docker-image:
+build-backend-prod:
   stage: deploy
   rules:
     - if: "$CI_COMMIT_TAG"
+  cache:
+    paths:
+      - .trivycache/
   script:
     - apk add make curl
     - curl -SL https://github.com/docker/compose/releases/download/v2.6.0/docker-compose-linux-x86_64 -o /usr/local/bin/docker-compose
     - chmod +x /usr/local/bin/docker-compose
     - make init
     - docker build --target prod -t iqbberlin/testcenter-backend:$CI_COMMIT_TAG -f docker/backend.Dockerfile .
-    - docker build --target prod -t iqbberlin/testcenter-frontend:$CI_COMMIT_TAG -f docker/frontend.Dockerfile .
-    - docker build --target prod -t iqbberlin/testcenter-broadcasting-service:$CI_COMMIT_TAG -f docker/broadcasting-service.Dockerfile .
+    - |
+      docker run --rm \
+      -v /.trivycache/:/.trivycache/ -v /builds/iqb/testcenter/:/root/ -v /var/run/docker.sock:/var/run/docker.sock \
+      aquasec/trivy image --exit-code 0 --cache-dir .trivycache/ --security-checks vuln \
+      --format template --template "@contrib/gitlab.tpl" -o /root/gl-container-scanning-report.json \
+      iqbberlin/testcenter-backend:$CI_COMMIT_TAG
     - echo "$DOCKERHUB_PASSWORD" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
     - docker push iqbberlin/testcenter-backend:$CI_COMMIT_TAG
+  artifacts:
+    reports:
+      container_scanning: gl-container-scanning-report.json
+
+build-frontend-prod:
+  stage: deploy
+  rules:
+    - if: "$CI_COMMIT_TAG"
+  cache:
+    paths:
+      - .trivycache/
+  script:
+    - apk add make curl
+    - curl -SL https://github.com/docker/compose/releases/download/v2.6.0/docker-compose-linux-x86_64 -o /usr/local/bin/docker-compose
+    - chmod +x /usr/local/bin/docker-compose
+    - make init
+    - docker build --target prod -t iqbberlin/testcenter-frontend:$CI_COMMIT_TAG -f docker/frontend.Dockerfile .
+    - |
+      docker run --rm \
+      -v /.trivycache/:/.trivycache/ -v /builds/iqb/testcenter/:/root/ -v /var/run/docker.sock:/var/run/docker.sock \
+      aquasec/trivy image --exit-code 0 --cache-dir .trivycache/ --security-checks vuln \
+      --format template --template "@contrib/gitlab.tpl" -o /root/gl-container-scanning-report.json \
+      iqbberlin/testcenter-frontend:$CI_COMMIT_TAG
+    - echo "$DOCKERHUB_PASSWORD" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
     - docker push iqbberlin/testcenter-frontend:$CI_COMMIT_TAG
+  artifacts:
+    reports:
+      container_scanning: gl-container-scanning-report.json
+
+build-broadcasting-service-prod:
+  stage: deploy
+  rules:
+    - if: "$CI_COMMIT_TAG"
+  cache:
+    paths:
+      - .trivycache/
+  script:
+    - apk add make curl
+    - curl -SL https://github.com/docker/compose/releases/download/v2.6.0/docker-compose-linux-x86_64 -o /usr/local/bin/docker-compose
+    - chmod +x /usr/local/bin/docker-compose
+    - make init
+    - docker build --target prod -t iqbberlin/testcenter-broadcasting-service:$CI_COMMIT_TAG -f docker/broadcasting-service.Dockerfile .
+    - |
+      docker run --rm \
+      -v /.trivycache/:/.trivycache/ -v /builds/iqb/testcenter/:/root/ -v /var/run/docker.sock:/var/run/docker.sock \
+      aquasec/trivy image --exit-code 0 --cache-dir .trivycache/ --security-checks vuln \
+      --format template --template "@contrib/gitlab.tpl" -o /root/gl-container-scanning-report.json \
+      iqbberlin/testcenter-broadcasting-service:$CI_COMMIT_TAG
+    - echo "$DOCKERHUB_PASSWORD" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
     - docker push iqbberlin/testcenter-broadcasting-service:$CI_COMMIT_TAG
+  artifacts:
+    reports:
+      container_scanning: gl-container-scanning-report.json
 
 generate-docs:
   stage: build


### PR DESCRIPTION
- Only triggered by creating prod build (tags)
- Split up build jobs for the 3 components This is necessary because the scanning report can only be a single file.  By having different jobs, the 3 reports are automatically merged (and  shown on the "Security" tab in GitLab).
- For scanning the tool "trivy" is used. "exit-code 0" means that the job never fails even though issues might  have been found. This is necessary because GitLab does not accept  artifacts (reports) from failed jobs.
The format paramaters are for GitLab, so it can show the results on the  "Security" tab of the pipeline.