### PR TITLE
Display last modification date on superadmin workspace

### DIFF
--- a/backend/src/dao/SuperAdminDAO.class.php
+++ b/backend/src/dao/SuperAdminDAO.class.php
@@ -5,7 +5,11 @@ declare(strict_types=1);
 class SuperAdminDAO extends DAO {
   public function getWorkspaces(): array {
     return $this->_(
-      'select workspaces.id, workspaces.name from workspaces order by workspaces.name',
+      'select workspaces.id, workspaces.name, MAX(files.modification_ts) AS latest_modification_ts
+      FROM workspaces
+      LEFT JOIN files ON workspaces.id = files.workspace_id
+      GROUP BY workspaces.id, workspaces.name
+      ORDER BY workspaces.name',
       [],
       true
     );

--- a/backend/test/unit/dao/SuperAdminDAOTest.php
+++ b/backend/test/unit/dao/SuperAdminDAOTest.php
@@ -34,7 +34,8 @@ class SuperAdminDAOTest extends TestCase {
     $expectation = array(
       array(
         "id" => 1,
-        "name" => "example_workspace"
+        "name" => "example_workspace",
+        "latest_modification_ts" => "2023-01-16 09:00:00"
       )
     );
     $this->assertEquals($expectation, $result);
@@ -255,11 +256,13 @@ class SuperAdminDAOTest extends TestCase {
     $expectation = [
       [
         "id" => 1,
-        "name" => "example_workspace"
+        "name" => "example_workspace",
+        "latest_modification_ts" => "2023-01-16 09:00:00"
       ],
       [
         "id" => 2,
-        "name" => "new_workspace"
+        "name" => "new_workspace",
+        "latest_modification_ts" => null
       ],
 
     ];

--- a/frontend/src/app/superadmin/workspaces/workspaces.component.html
+++ b/frontend/src/app/superadmin/workspaces/workspaces.component.html
@@ -50,10 +50,14 @@
           </mat-checkbox>
         </mat-cell>
       </ng-container>
-
       <ng-container matColumnDef="name">
         <mat-header-cell *matHeaderCellDef mat-sort-header class="table-header">Name</mat-header-cell>
         <mat-cell *matCellDef="let element">{{element.name}}</mat-cell>
+      </ng-container>
+
+      <ng-container matColumnDef="modification_timestamp">
+        <mat-header-cell *matHeaderCellDef mat-sort-header class="table-header">Letztes Änderungsdatum</mat-header-cell>
+        <mat-cell *matCellDef="let element">{{element.latest_modification_ts}}</mat-cell>
       </ng-container>
 
       <mat-header-row *matHeaderRowDef="displayedColumns"></mat-header-row>

--- a/frontend/src/app/superadmin/workspaces/workspaces.component.html
+++ b/frontend/src/app/superadmin/workspaces/workspaces.component.html
@@ -57,7 +57,7 @@
 
       <ng-container matColumnDef="modification_timestamp">
         <mat-header-cell *matHeaderCellDef mat-sort-header class="table-header">Letztes Änderungsdatum</mat-header-cell>
-        <mat-cell *matCellDef="let element">{{element.latest_modification_ts}}</mat-cell>
+        <mat-cell *matCellDef="let element">{{element.latest_modification_ts | date: 'dd.MM.yy HH:mm'}}</mat-cell>
       </ng-container>
 
       <mat-header-row *matHeaderRowDef="displayedColumns"></mat-header-row>

--- a/frontend/src/app/superadmin/workspaces/workspaces.component.ts
+++ b/frontend/src/app/superadmin/workspaces/workspaces.component.ts
@@ -20,7 +20,7 @@ import { IdAndName, IdRoleData } from '../superadmin.interfaces';
 })
 export class WorkspacesComponent implements OnInit {
   workspaces: MatTableDataSource<IdAndName> = new MatTableDataSource<IdAndName>();
-  displayedColumns = ['selectCheckbox', 'name'];
+  displayedColumns = ['selectCheckbox', 'name', 'modification_timestamp'];
   tableSelectionCheckbox = new SelectionModel<IdAndName>(true, []);
   tableSelectionRow = new SelectionModel<IdAndName>(false, []);
   selectedWorkspaceId = 0;


### PR DESCRIPTION
Resolves #227.
Im Superadminbereich werden nun für jeden Arbeitsbereich auch das Letzte Änderungsdatum angezeigt.

Was mir allerdings aufgefallen ist, ist dass die Logik hinter dem latest_modification_ts evtl etwas irreführend ist.
Wenn man nur Dateien hinzufügt, dann klappt das alles so wie es sein sollte. 
Wenn man aber die zuletzt geuploadete Datei löscht, so wird nun der Timestamp der vorletzten geuploadeten Datei als letztes Änderungsdatum benutzt und nicht der Zeitpunkt an dem eine Datei gelöscht wurde.
