### PR TITLE
[infrastructure] Fix TLS config file name in PROD

### DIFF
--- a/dist-src/docker-compose.prod.tls.yml
+++ b/dist-src/docker-compose.prod.tls.yml
@@ -13,12 +13,12 @@ services:
       - "--entrypoints.web.http.redirections.entryPoint.scheme=https"
       - "--entrypoints.websecure.address=:443"
       - "--entrypoints.websecure.http.tls.options=default@file"
-      - "--providers.file.filename=/ssl-config.yml"
+      - "--providers.file.filename=/tls-config.yml"
     ports:
       - "${TLS_PORT}:443"
     volumes:
       - ./config/certs/:/certs/
-      - ./config/ssl-config.yml:/ssl-config.yml
+      - ./config/tls-config.yml:/tls-config.yml
 
   testcenter-backend:
     labels:

--- a/dist-src/install.sh
+++ b/dist-src/install.sh
@@ -88,7 +88,7 @@ customize_settings() {
 set_tls() {
   read  -p 'Use TLS? [y/N]: ' -r -n 1 -e TLS
   if [[ $TLS =~ ^[yY]$ ]]; then
-    printf "The certificates need to be put in config/certs and their file name configured in config/ssl-config.yml.\n"
+    printf "The certificates need to be put in config/certs and their file name configured in config/tls-config.yml.\n"
     sed -i 's/TLS_ENABLED=no/TLS_ENABLED=yes/' .env
     sed -i 's/docker-compose.prod.yml/docker-compose.prod.yml -f docker-compose.prod.tls.yml/' Makefile
   fi


### PR DESCRIPTION
The compose file still referenced the old name, which led to errors.