### PR TITLE
[frontend] Improve unit navigatin bar styling

### DIFF
--- a/frontend/src/app/test-controller/components/test-controller/test-controller.component.css
+++ b/frontend/src/app/test-controller/components/test-controller/test-controller.component.css
@@ -26,9 +26,7 @@ h1 {
 }
 
 .unit-nav {
-  /*max-width: 50%;*/
-  margin-right: 10px;
-  align-items: center;
+  margin: 0 5px;
   flex-wrap: wrap;
   z-index: 2;
   max-height: 100%;
@@ -37,8 +35,7 @@ h1 {
 .unit-nav .unit-nav-item {
   font-size: 12px;
   border-radius: 0;
-  max-width: 200px;
-  height: 36px;
+  height: 30px;
   white-space: normal;
   line-height: normal;
   display: flex;
@@ -46,6 +43,10 @@ h1 {
   justify-content: center;
   overflow-x: clip;
   overflow-y: auto;
+  margin-bottom: 2px;
+  width: 30px;
+  padding: 0;
+  min-width: unset;
 }
 
 /* Workaround for non-Firefox Browsers, which don't support "safe" in align-items.
@@ -55,20 +56,12 @@ appear as if aligned with "start". */
   margin: auto;
 }
 
-.unit-nav a.mat-button-disabled {
-  background-color: darkgray;
-}
-
 .unit-nav a:not(:last-child) {
   border-right: lightgray 1px solid;
 }
 
 .unit-nav-item-selected {
   background-color: var(--accent);
-}
-
-.unit-nav-item-selected[disabled="true"] {
-  color: black;
 }
 
 .debug-pane {
@@ -95,4 +88,12 @@ appear as if aligned with "start". */
 
 .mat-drawer-container {
   background: transparent !important;
+}
+
+.mat-fab.mat-button-disabled {
+  background-color: lightgray;
+}
+
+.unit-nav-item.mat-flat-button.mat-button-disabled {
+  background-color: lightgray;
 }

--- a/frontend/src/app/test-controller/components/test-controller/test-controller.component.html
+++ b/frontend/src/app/test-controller/components/test-controller/test-controller.component.html
@@ -18,54 +18,44 @@
   </p>
 
   <div *ngIf="(tcs.bookletConfig.unit_navibuttons !== 'OFF') && ((tcs.testStatus$ | async) === tcs.testStatusEnum.RUNNING)"
-       class="unit-nav flex-row" [style.margin-left]="'auto'">
-    <a mat-fab
-       *ngIf="tcs.bookletConfig.controller_design === '2018'"
+       class="flex-row" [style.align-items]="'safe center'" [style.max-height.%]="100" [style.margin-left]="'auto'">
+    <a *ngIf="tcs.bookletConfig.controller_design === '2018'"
+       mat-fab matTooltip="Zurück" data-cy="unit-navigation-backward"
        [disabled]="tcs.currentUnitSequenceId <= 1"
-       (click)="tcs.setUnitNavigationRequest(unitNavigationTarget.PREVIOUS)"
-       matTooltip="Zurück"
-       data-cy="unit-navigation-backward">
+       (click)="tcs.setUnitNavigationRequest(unitNavigationTarget.PREVIOUS)">
       <i class="material-icons">chevron_left</i>
     </a>
-    <a mat-flat-button
-       *ngIf="tcs.bookletConfig.controller_design !== '2018'"
+    <a *ngIf="tcs.bookletConfig.controller_design !== '2018'"
+       mat-flat-button matTooltip="Zurück" data-cy="unit-navigation-backward"
        [style.border-radius]="0"
        [disabled]="tcs.currentUnitSequenceId <= 1"
-       (click)="tcs.setUnitNavigationRequest(unitNavigationTarget.PREVIOUS)"
-       matTooltip="Zurück"
-       data-cy="unit-navigation-backward">
+       (click)="tcs.setUnitNavigationRequest(unitNavigationTarget.PREVIOUS)">
       <i class="material-icons">chevron_left</i>
     </a>
 
-    <ng-container *ngIf="tcs.bookletConfig.unit_navibuttons !== 'ARROWS_ONLY'">
+    <div *ngIf="tcs.bookletConfig.unit_navibuttons !== 'ARROWS_ONLY'" class="unit-nav flex-row">
       <ng-container *ngFor="let u of unitNavigationList">
-        <a
-           *ngIf="u.sequenceId"
-           mat-flat-button
-           class="unit-nav-item" [class.unit-nav-item-selected]="u.isCurrent"
+        <a *ngIf="u.sequenceId"
+           mat-flat-button class="unit-nav-item" [class.unit-nav-item-selected]="u.isCurrent"
            [attr.aria-label]="u.longLabel" [attr.data-cy]="u.shortLabel"
            [disabled]="u.disabled"
            (click)="tcs.setUnitNavigationRequest(u.sequenceId.toString())">
           {{u.shortLabel ? u.shortLabel : '&nbsp;'}}
         </a>
       </ng-container>
-    </ng-container>
+    </div>
 
-    <a mat-fab
-       *ngIf="tcs.bookletConfig.controller_design === '2018'"
+    <a *ngIf="tcs.bookletConfig.controller_design === '2018'"
+       mat-fab matTooltip="Weiter" data-cy="unit-navigation-forward"
        [disabled]="tcs.currentUnitSequenceId >= tcs.allUnitIds.length"
-       (click)="tcs.setUnitNavigationRequest(unitNavigationTarget.NEXT)"
-       matTooltip="Weiter"
-       data-cy="unit-navigation-forward">
+       (click)="tcs.setUnitNavigationRequest(unitNavigationTarget.NEXT)">
       <i class="material-icons">chevron_right</i>
     </a>
-    <a mat-flat-button
-       *ngIf="tcs.bookletConfig.controller_design !== '2018'"
+    <a *ngIf="tcs.bookletConfig.controller_design !== '2018'"
+       mat-flat-button matTooltip="Weiter" data-cy="unit-navigation-forward"
        [style.border-radius]="0"
        [disabled]="tcs.currentUnitSequenceId >= tcs.allUnitIds.length"
-       (click)="tcs.setUnitNavigationRequest(unitNavigationTarget.NEXT)"
-       matTooltip="Weiter"
-       data-cy="unit-navigation-forward">
+       (click)="tcs.setUnitNavigationRequest(unitNavigationTarget.NEXT)">
       <i class="material-icons">chevron_right</i>
     </a>
   </div>


### PR DESCRIPTION
- Forward and Back buttons now always stay beside the actual unit button
- Reduce the size of unit buttons, so that more of them can be present  before wrapping to the next line
- Use lighter gray for disabled buttons
- Restructure element properties to be more logical (directives first,  outputs last etc)