### PR TITLE
Fix for small typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The IQB-Testcenter is a web application for technology based accessed and survey
 ### Test Coverage
 * [Backend by Unit-Tests](https://pages.cms.hu-berlin.de/iqb/testcenter/dist/test-coverage-backend-unit/index.html)
 * [Frontend by Unit-Tests](https://pages.cms.hu-berlin.de/iqb/testcenter/dist/test-coverage-frontend-unit/report/index.html)
-* [Broadcasting-Service by Unit-Tets](https://pages.cms.hu-berlin.de/iqb/testcenter/dist/test-coverage-broadcasting-service-unit/lcov-report/index.html)
+* [Broadcasting-Service by Unit-Tests](https://pages.cms.hu-berlin.de/iqb/testcenter/dist/test-coverage-broadcasting-service-unit/lcov-report/index.html)
 
 ### Misc
 * [Install and run without docker](https://pages.cms.hu-berlin.de/iqb/testcenter/pages/installation-local.html)


### PR DESCRIPTION
Fix for a small typo.

"Broadcasting-Service by Unit-Tets" -> "Broadcasting-Service by Unit-Tests"