### PR TITLE
Update fe/bs node version

### DIFF
--- a/docker/broadcasting-service.Dockerfile
+++ b/docker/broadcasting-service.Dockerfile
@@ -1,4 +1,4 @@
-ARG NODE_VERSION=16.19-bullseye-slim
+ARG NODE_VERSION=20.9.0-bookworm-slim
 
 FROM node:${NODE_VERSION} as dev
 

--- a/docker/frontend.Dockerfile
+++ b/docker/frontend.Dockerfile
@@ -1,4 +1,6 @@
-FROM node:16.19-bullseye as dev
+ARG NODE_VERSION=20.9.0-bookworm-slim
+
+FROM node:${NODE_VERSION} as dev
 
 ARG NODE_ENV=development
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -37,7 +37,6 @@
     "@types/ua-parser-js": "^0.7.36",
     "browserslist-useragent": "^4.0.0",
     "core-js": "^3.24.0",
-    "fibers": "^5.0.2",
     "html-webpack-plugin": "^5.5.0",
     "material-design-icons": "~3.0.1",
     "qr-scanner": "1.4.1",


### PR DESCRIPTION
Node wurde auf die gewünschte Versiob (20.9.0-bookworm-slim) hochgezogen.
Das fibers package ist nicht mit node 16+ kompatibel. Habe jetzt aber auch nicht gesehen wo das konkret benötigt wurde und deswegen erstmal entfernt. Falls ich was übersehen habe und das dringend notwendig ist, gib gerne Bescheid.