### PR TITLE
fe: Superadmin: replace all buttons with fab

### DIFF
--- a/frontend/src/app/superadmin/settings/app-config.component.html
+++ b/frontend/src/app/superadmin/settings/app-config.component.html
@@ -50,7 +50,7 @@
     <img class="logo-img" [src]="logoImageBase64" />
     <input #hiddenimgfileinput type="file" (change)="imgFileChange($event)" [hidden]="true"/>
     <button
-      mat-raised-button
+      mat-fab
       (click)="hiddenimgfileinput.click()"
       matTooltip="Logo hochladen/aktualisieren"
       matTooltipPosition="above"
@@ -59,7 +59,7 @@
       <mat-icon>cloud_upload</mat-icon>
     </button>
     <button
-      mat-raised-button
+      mat-fab
       (click)="removeLogoImg()"
       matTooltip="Logo auf Standard setzen"
       matTooltipPosition="above"

--- a/frontend/src/app/superadmin/settings/app-config.component.html
+++ b/frontend/src/app/superadmin/settings/app-config.component.html
@@ -46,29 +46,21 @@
   </mat-form-field>
 
   <h4>Logo</h4>
-  <div class="flex-row-wrap" [style.align-items]="'center'" [style.gap.px]="10">
-    <img class="logo-img" [src]="logoImageBase64" />
-    <input #hiddenimgfileinput type="file" (change)="imgFileChange($event)" [hidden]="true"/>
-    <button
-      mat-fab
-      (click)="hiddenimgfileinput.click()"
-      matTooltip="Logo hochladen/aktualisieren"
-      matTooltipPosition="above"
-      color="primary"
-    >
+  <div class="flex-row" [style.gap.px]="5">
+    <button mat-mini-fab color="primary"
+            matTooltip="Logo hochladen/aktualisieren" matTooltipPosition="above"
+            (click)="hiddenimgfileinput.click()">
       <mat-icon>cloud_upload</mat-icon>
     </button>
-    <button
-      mat-fab
-      (click)="removeLogoImg()"
-      matTooltip="Logo auf Standard setzen"
-      matTooltipPosition="above"
-      color="primary"
-    >
+    <button mat-mini-fab color="primary"
+            matTooltip="Logo auf Standard setzen" matTooltipPosition="above"
+            (click)="removeLogoImg()">
       <mat-icon>delete</mat-icon>
     </button>
-    <tc-alert *ngIf="imageError" level="error" [text]="imageError"></tc-alert>
   </div>
+  <img class="logo-img" [src]="logoImageBase64" />
+  <input #hiddenimgfileinput type="file" (change)="imgFileChange($event)" [hidden]="true"/>
+  <tc-alert *ngIf="imageError" level="error" [text]="imageError"></tc-alert>
 
   <h4>Hintergrundfarbe Anwendung</h4>
   <mat-form-field appearance="fill">

--- a/frontend/src/app/superadmin/users/users.component.css
+++ b/frontend/src/app/superadmin/users/users.component.css
@@ -1,5 +1,4 @@
-.mat-mdc-raised-button {
-  min-width: 100px;
+.mat-mdc-fab {
   margin: 2px;
 }
 

--- a/frontend/src/app/superadmin/users/users.component.html
+++ b/frontend/src/app/superadmin/users/users.component.html
@@ -2,43 +2,47 @@
   <div class="flex-column" [style.width.%]="50">
     <div class="flex-row">
       <button
-        mat-raised-button
+        mat-fab
         matTooltip="Administrator:in hinzufügen"
         matTooltipPosition="below"
         data-cy="add-user"
-        (click)="addObject()"
         color="primary"
+        (click)="addObject()"
       >
         <mat-icon>add</mat-icon>
       </button>
       <button
-        mat-raised-button data-cy="delete-user"
+        mat-fab
         matTooltip="Markierte Administrator:in löschen"
         matTooltipPosition="below"
-        (click)="deleteObject()"
+        data-cy="delete-user"
         color="primary"
+        [disabled]="!tableSelectionRow.hasValue()"
+        (click)="deleteObject()"
       >
         <mat-icon>delete</mat-icon>
       </button>
       <button
-        mat-raised-button
+        mat-fab
         data-cy="change-password"
         matTooltip="Kennwort ändern"
         matTooltipPosition="below"
-        (click)="changePassword()"
         color="primary"
+        [disabled]="!tableSelectionRow.hasValue()"
+        (click)="changePassword()"
       >
         <mat-icon>edit</mat-icon>
       </button>
       <button
-        mat-raised-button
+        mat-fab
         data-cy="change-superadmin"
         matTooltip="Superadmin-Status ändern"
         matTooltipPosition="below"
-        (click)="changeSuperadminStatus()"
         color="primary"
+        [disabled]="!tableSelectionRow.hasValue()"
+        (click)="changeSuperadminStatus()"
       >
-        <mat-icon>edit</mat-icon>
+        <mat-icon>supervisor_account</mat-icon>
       </button>
     </div>
 
@@ -68,7 +72,7 @@
 
       <mat-header-row *matHeaderRowDef="displayedColumns"></mat-header-row>
       <mat-row *matRowDef="let row; columns: displayedColumns;" (click)="selectRow(row)"
-               [style.background]="tableselectionRow.isSelected(row) ? 'lightblue' : ''"></mat-row>
+               [style.background]="tableSelectionRow.isSelected(row) ? 'lightblue' : ''"></mat-row>
     </mat-table>
   </div>
 
@@ -81,7 +85,7 @@
     <div *ngIf="selectedUser > 0" class="flex-row" [style.justify-content]="'space-between'">
       <div>Zugriffsrechte für {{ selectedUserName }}:</div>
       <button
-        mat-raised-button
+        mat-fab
         (click)="saveWorkspaces()"
         matTooltip="Speichern"
         matTooltipPosition="above"

--- a/frontend/src/app/superadmin/users/users.component.ts
+++ b/frontend/src/app/superadmin/users/users.component.ts
@@ -21,10 +21,10 @@ import { NewPasswordComponent } from './newpassword/new-password.component';
   styleUrls: ['./users.component.css']
 })
 export class UsersComponent implements OnInit {
-  objectsDatasource: MatTableDataSource<UserData> = new MatTableDataSource<UserData>;
+  objectsDatasource: MatTableDataSource<UserData> = new MatTableDataSource<UserData>();
   displayedColumns = ['selectCheckbox', 'name'];
   tableselectionCheckbox = new SelectionModel<UserData>(true, []);
-  tableselectionRow = new SelectionModel<UserData>(false, []);
+  tableSelectionRow = new SelectionModel<UserData>(false, []);
   selectedUser = -1;
   selectedUserName = '';
 
@@ -43,7 +43,7 @@ export class UsersComponent implements OnInit {
     private messsageDialog: MatDialog,
     private snackBar: MatSnackBar
   ) {
-    this.tableselectionRow.changed.subscribe(
+    this.tableSelectionRow.changed.subscribe(
       r => {
         if (r.added.length > 0) {
           this.selectedUser = r.added[0].id;
@@ -80,7 +80,7 @@ export class UsersComponent implements OnInit {
   }
 
   changeSuperadminStatus(): void {
-    let selectedRows = this.tableselectionRow.selected;
+    let selectedRows = this.tableSelectionRow.selected;
     if (selectedRows.length === 0) {
       selectedRows = this.tableselectionCheckbox.selected;
     }
@@ -119,7 +119,7 @@ export class UsersComponent implements OnInit {
   }
 
   changePassword(): void {
-    let selectedRows = this.tableselectionRow.selected;
+    let selectedRows = this.tableSelectionRow.selected;
     if (selectedRows.length === 0) {
       selectedRows = this.tableselectionCheckbox.selected;
     }
@@ -160,7 +160,7 @@ export class UsersComponent implements OnInit {
   deleteObject(): void {
     let selectedRows = this.tableselectionCheckbox.selected;
     if (selectedRows.length === 0) {
-      selectedRows = this.tableselectionRow.selected;
+      selectedRows = this.tableSelectionRow.selected;
     }
     if (selectedRows.length === 0) {
       this.messsageDialog.open(MessageDialogComponent, {
@@ -238,7 +238,7 @@ export class UsersComponent implements OnInit {
 
   updateObjectList(): void {
     this.tableselectionCheckbox.clear();
-    this.tableselectionRow.clear();
+    this.tableSelectionRow.clear();
     this.bs.getUsers().subscribe(dataresponse => {
       this.objectsDatasource = new MatTableDataSource(dataresponse);
       this.objectsDatasource.sort = this.sort;
@@ -259,6 +259,6 @@ export class UsersComponent implements OnInit {
   }
 
   selectRow(row: UserData): void {
-    this.tableselectionRow.select(row);
+    this.tableSelectionRow.select(row);
   }
 }

--- a/frontend/src/app/superadmin/workspaces/workspaces.component.css
+++ b/frontend/src/app/superadmin/workspaces/workspaces.component.css
@@ -1,5 +1,4 @@
-.mat-mdc-raised-button {
-  min-width: 100px;
+.mat-mdc-fab {
   margin: 2px;
 }
 

--- a/frontend/src/app/superadmin/workspaces/workspaces.component.html
+++ b/frontend/src/app/superadmin/workspaces/workspaces.component.html
@@ -2,32 +2,34 @@
   <div class="flex-column" [style.width.%]="50">
     <div class="flex-row">
       <button
-        mat-raised-button
-        (click)="addObject()"
+        mat-fab
         matTooltip="Arbeitsbereich hinzufügen"
         matTooltipPosition="below"
         data-cy="add-workspace"
         color="primary"
+        (click)="addObject()"
         >
           <mat-icon>add</mat-icon>
       </button>
       <button
-        mat-raised-button
-        (click)="deleteObject()"
+        mat-fab
         matTooltip="Markierte/n Arbeitsbereich/e löschen"
         matTooltipPosition="below"
         data-cy="delete-workspace"
         color="primary"
+        [disabled]="!tableSelectionRow.hasValue()"
+        (click)="deleteObject()"
       >
         <mat-icon>delete</mat-icon>
       </button>
       <button
-        mat-raised-button
-        (click)="changeObject()"
+        mat-fab
         matTooltip="Arbeitsbereich umbenennen"
         matTooltipPosition="below"
         data-cy="rename-workspace"
         color="primary"
+        [disabled]="!tableSelectionRow.hasValue()"
+        (click)="changeObject()"
       >
         <mat-icon>edit</mat-icon>
       </button>
@@ -74,8 +76,8 @@
 
     <div *ngIf="selectedWorkspaceId > 0" class="flex-row" [style.justify-content]="'space-between'">
       <div>Zugriffsrechte für "{{ selectedWorkspaceName }}":</div>
-        <button mat-raised-button (click)="saveUsers()" matTooltip="Speichern"
-            matTooltipPosition="above" [disabled]="!pendingUserChanges" data-cy="save">
+        <button mat-fab  matTooltip="Speichern"
+            matTooltipPosition="above" data-cy="save" [disabled]="!pendingUserChanges" (click)="saveUsers()" >
           <mat-icon>save</mat-icon>
         </button>
     </div>

--- a/frontend/src/app/superadmin/workspaces/workspaces.component.ts
+++ b/frontend/src/app/superadmin/workspaces/workspaces.component.ts
@@ -3,7 +3,6 @@ import { ViewChild, Component, OnInit } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { MatSort } from '@angular/material/sort';
-import { FormGroup } from '@angular/forms';
 import { SelectionModel } from '@angular/cdk/collections';
 import {
   ConfirmDialogComponent, ConfirmDialogData,


### PR DESCRIPTION
Resolves #379.

Ich habe mich dafür entschieden Buttons die nur ein Icon enthalten als floating action button darzustellen. Ist dann auch etwas mehr im Einklang mit der Material Doku.
Im Admins Tab und im Arbeitsbereich Tab sind alle Buttons nun Fabs.
Im Einstellungs Tab sind die Buttons zum Hochladen bzw Löschen des Logos auch Fabs.

Die Buttons im Admin/Arbeitsbereich Tab zum löschen/ändern sind deaktiviert bis man etwas ausgewählt hat.

Beim  Admin Tab habe ich das Icon von "Superadmin Status ändern" geändert, damit wir nicht zwei Buttons mit denselben Icons haben.
Mein Vorschlag sieht so aus (ganz rechts ist wie davor der Button um den Superadmin Status zu ändern):
![new_buttons](https://github.com/iqb-berlin/testcenter/assets/78593320/44fc5de9-27cb-4e59-a223-2cecbf85b792)
