### PR TITLE
[frontend] Fix error hiding in super admin settings

### DIFF
--- a/frontend/src/app/superadmin/settings/app-config.component.ts
+++ b/frontend/src/app/superadmin/settings/app-config.component.ts
@@ -73,7 +73,7 @@ export class AppConfigComponent implements OnInit, OnDestroy {
     setTimeout(() => {
       const appConfig = this.mainDataService.appConfig?.getAppConfig();
       if (!appConfig) {
-        return;
+        throw new Error('AppConfigComponent: No AppConfig found');
       }
       this.configForm.setValue({
         appTitle: appConfig.appTitle,


### PR DESCRIPTION
Ich wollte noch ein klein wenig nachbessern, bei Huanings Verbesserungen (anderer PR). Habe mich dabei gewundert, warum das Logo auf der Admin-Seite manchmal einfach nicht erscheint. Der Grund ist, dass das AppConfig-Object nicht da ist, er aber trotzdem weitermacht, als wäre nix gewesen.

Hier ist der Fix, damit korrekt ein Error kommt.

Allerdings wäre herauszufinden, warum das Object manchmal einfach nicht da ist. Passiert leider nicht immer, aber in ca. 50% der Fälle. Zum reproduzieren einfach immer wieder neu laden.