### PR TITLE
fe:Add optional cancelbutton label for confirmDialog

### DIFF
--- a/frontend/src/app/shared/components/confirm-dialog/confirm-dialog.component.html
+++ b/frontend/src/app/shared/components/confirm-dialog/confirm-dialog.component.html
@@ -8,5 +8,5 @@
 
 <mat-dialog-actions>
   <button mat-raised-button color="primary" [mat-dialog-close]="true" data-cy="dialog-confirm">{{ confirmdata.confirmbuttonlabel }}</button>
-  <button mat-raised-button *ngIf="showcancel" [mat-dialog-close]="false" data-cy="dialog-cancel">Abbrechen</button>
+  <button mat-raised-button *ngIf="showcancel" [mat-dialog-close]="false" data-cy="dialog-cancel">{{ confirmdata.cancelbuttonlabel }}</button>
 </mat-dialog-actions>

--- a/frontend/src/app/shared/components/confirm-dialog/confirm-dialog.component.ts
+++ b/frontend/src/app/shared/components/confirm-dialog/confirm-dialog.component.ts
@@ -25,5 +25,11 @@ export class ConfirmDialogComponent implements OnInit {
     if (!this.confirmdata.showcancel) {
       this.showcancel = false;
     }
+    if (
+      (typeof this.confirmdata.cancelbuttonlabel === 'undefined') ||
+      (this.confirmdata.cancelbuttonlabel.length === 0)
+    ) {
+      this.confirmdata.cancelbuttonlabel = 'Abbrechen';
+    }
   }
 }

--- a/frontend/src/app/shared/interfaces/confirm-dialog.interfaces.ts
+++ b/frontend/src/app/shared/interfaces/confirm-dialog.interfaces.ts
@@ -3,4 +3,5 @@ export interface ConfirmDialogData {
   content: string;
   confirmbuttonlabel: string;
   showcancel: boolean;
+  cancelbuttonlabel?: string;
 }

--- a/frontend/src/app/test-controller/components/test-controller/test-controller.component.ts
+++ b/frontend/src/app/test-controller/components/test-controller/test-controller.component.ts
@@ -456,7 +456,8 @@ export class TestControllerComponent implements OnInit, OnDestroy {
         title: 'Vollbild',
         content: this.cts.getCustomText('booklet_requestFullscreen'),
         confirmbuttonlabel: 'Ja',
-        showcancel: true
+        showcancel: true,
+        cancelbuttonlabel: 'Nein'
       }
     });
     dialogRef.afterClosed().subscribe(async (confirmed: boolean) => {


### PR DESCRIPTION
Resolves #441.

Habe für confirmDialog ein optionales cancel button Label hinzugefügt.
Das default Label ist "Abbrechen", falls nichts extra angegeben.