### PR TITLE
[fe] Fix page navigation panel in syscheck and refactor page nav

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,7 @@ layout: default
 ### Bugfixes
 * Wurde man vom Gruppenmonitor in einen Zeitbeschränkten Block verschoben, in dem man sich bereits befand, so wurde
   dieser beendet und gesperrt. Dies ist behoben. (#447)
+* System-Check: Seitennavigationsleiste repariert
 
 ### Neue Features
 * Auf besonderen Wunsch wurden die Restriktionen für Login-Namen gelockert. Es sind nun beliebige Zeichenketten erlaubt.

--- a/frontend/src/app/shared/components/page-nav-bar/page-nav-bar.component.ts
+++ b/frontend/src/app/shared/components/page-nav-bar/page-nav-bar.component.ts
@@ -1,0 +1,45 @@
+import {
+  Component, EventEmitter, Input, Output
+} from '@angular/core';
+
+@Component({
+  selector: 'tc-page-nav',
+  template: `
+    <span [style.color]="'white'" [style.padding-right.px]="8">
+        {{ ''  | customtext:'login_pagesNaviPrompt' | async}}
+    </span>
+
+    <button mat-stroked-button [disabled]="currentPageIndex == 0"
+                       (click)="navPrevious.emit()">
+      <i class="material-icons">chevron_left</i>
+    </button>
+
+    <mat-button-toggle-group [value]="currentPageIndex">
+      <mat-button-toggle *ngFor="let page of pages; let index = index"
+                         [class.selectedValue]="currentPageIndex == index"
+                         [matTooltip]="page"
+                         [attr.data-cy]="'page-navigation-' + index"
+                         [value]="index"
+                         (click)="navToPage.emit(index)">
+        {{ index + 1 }}
+      </mat-button-toggle>
+    </mat-button-toggle-group>
+
+    <button mat-stroked-button [disabled]="currentPageIndex == pages.length - 1"
+                       (click)="navNext.emit()">
+      <i class="material-icons">chevron_right</i>
+    </button>
+  `,
+  styles: [`
+    .selectedValue {background-color: var(--mat-standard-button-toggle-selected-state-background-color);}
+    button { height: 34px !important; margin-bottom: 2px;}
+    mat-button-toggle-group {height: 34px; align-items: center;}
+  `]
+})
+export class PageNavBarComponent {
+  @Input() pages: string[] = [];
+  @Input() currentPageIndex!: number;
+  @Output() navPrevious = new EventEmitter();
+  @Output() navNext = new EventEmitter();
+  @Output() navToPage = new EventEmitter<number>();
+}

--- a/frontend/src/app/shared/shared.module.ts
+++ b/frontend/src/app/shared/shared.module.ts
@@ -19,6 +19,8 @@ import { AlertComponent } from './components/alert/alert.component';
 import { ErrorComponent } from './components/error/error.component';
 import { BackendService } from './services/backend.service';
 import { customTextDefaults } from './objects/customTextDefaults';
+import { PageNavBarComponent } from './components/page-nav-bar/page-nav-bar.component';
+import { MatButtonToggleModule } from '@angular/material/button-toggle';
 
 @NgModule({
   imports: [
@@ -33,7 +35,8 @@ import { customTextDefaults } from './objects/customTextDefaults';
     FormsModule,
     MatInputModule,
     HttpClientModule,
-    MatTooltipModule
+    MatTooltipModule,
+    MatButtonToggleModule
   ],
   declarations: [
     ConfirmDialogComponent,
@@ -41,7 +44,8 @@ import { customTextDefaults } from './objects/customTextDefaults';
     BytesPipe,
     CustomtextPipe,
     AlertComponent,
-    ErrorComponent
+    ErrorComponent,
+    PageNavBarComponent
   ],
   exports: [
     ConfirmDialogComponent,
@@ -49,7 +53,8 @@ import { customTextDefaults } from './objects/customTextDefaults';
     BytesPipe,
     CustomtextPipe,
     AlertComponent,
-    ErrorComponent
+    ErrorComponent,
+    PageNavBarComponent
   ],
   providers: [
     BackendService

--- a/frontend/src/app/sys-check/unit-check/unit-check.component.css
+++ b/frontend/src/app/sys-check/unit-check/unit-check.component.css
@@ -15,7 +15,7 @@
   padding: 5px;
 }
 
-#pageNav {
+.pageNav {
   position: absolute;
   right: 0;
   height: 45px;
@@ -23,22 +23,4 @@
   padding: 0 30px;
   font-size: 1.2em;
   background: transparent;
-}
-
-#pageNav button {
-  font-size: 1.1em;
-}
-
-#pageNav button i {
-  font-size: 1.2em;
-}
-
-.pageNavDisabled {
-  height: 5px;
-  background-color: orangered;
-}
-
-.pageNavEnabled {
-  height: 5px;
-  background-color: darkgrey;
 }

--- a/frontend/src/app/sys-check/unit-check/unit-check.component.html
+++ b/frontend/src/app/sys-check/unit-check/unit-check.component.html
@@ -5,26 +5,12 @@
 
 <div #iFrameHost id="iFrameHost" *ngIf="!errorText"></div>
 
-<div id="pageNav" class="flex-row">
-  <div *ngIf="pageList.length > 1" class="flex-row">
-    <mat-button-toggle-group *ngFor="let p of pageList">
-      <mat-button-toggle *ngIf="p.type === '#previous'" (click)="gotoPage(p.type)" [disabled]="p.disabled">
-        <i class="material-icons">chevron_left</i>
-      </mat-button-toggle>
-      <mat-button-toggle *ngIf="p.type === '#next'" (click)="gotoPage(p.type)" [disabled]="p.disabled">
-        <i class="material-icons">chevron_right</i>
-      </mat-button-toggle>
-
-      <mat-button-toggle *ngIf="p.type === '#goto'"
-                         (click)="gotoPage(p.type, p.index)"
-                         [disabled]="p.disabled"
-                         [checked]="currentPage === p.index">
-        {{ p.index }}
-      </mat-button-toggle>
-
-    </mat-button-toggle-group>
-  </div>
-</div>
+<tc-page-nav class="pageNav"
+             [pages]="pageList" [currentPageIndex]="currentPageIndex"
+             (navToPage)="gotoPage($event)"
+             (navPrevious)="gotoPreviousPage()"
+             (navNext)="gotoNextPage()">
+</tc-page-nav>
 
 <mat-card appearance="outlined" *ngIf="errorText" [style.width.px]="700" [style.margin]="'auto'">
   <mat-card-header>

--- a/frontend/src/app/test-controller/components/unithost/unithost.component.css
+++ b/frontend/src/app/test-controller/components/unithost/unithost.component.css
@@ -24,7 +24,7 @@
 }
 
 .with-footer #iframe-host {
-  bottom: 45px;
+  bottom: 46px;
 }
 
 #waiting-room {
@@ -57,7 +57,7 @@
 .page-navigation {
   position: absolute;
   width: 100%;
-  height: 45px;
+  height: 46px;
   bottom: 0;
   font-size: 1.2em;
 }

--- a/frontend/src/app/test-controller/components/unithost/unithost.component.html
+++ b/frontend/src/app/test-controller/components/unithost/unithost.component.html
@@ -3,143 +3,127 @@
   'with-title': tcs.bookletConfig.unit_title === 'ON',
   'with-footer': tcs.bookletConfig.page_navibuttons === 'SEPARATE_BOTTOM',
   'is-waiting': currentUnit?.unitDef?.locked || (unitsLoading$ | async).length || codeRequiringTestlets.length}">
-<div *ngIf="tcs.bookletConfig.unit_title === 'ON'" class="unit-title">
-  <h2 data-cy="unit-title">{{currentUnit?.unitDef?.title}}</h2>
-  <mat-divider></mat-divider>
-</div>
+  <div *ngIf="tcs.bookletConfig.unit_title === 'ON'" class="unit-title">
+    <h2 data-cy="unit-title">{{currentUnit?.unitDef?.title}}</h2>
+    <mat-divider></mat-divider>
+  </div>
 
-<div #iframeHost id="iframe-host"></div>
+  <div #iframeHost id="iframe-host"></div>
 
-<ng-container *ngIf="{ list: (unitsLoading$ | async) } as loadingUnits">
-  <div id="waiting-room"  *ngIf="loadingUnits.list.length || currentUnit?.unitDef?.locked || codeRequiringTestlets.length">
-    <mat-card appearance="raised">
-      <mat-card-header>
-        <mat-card-title data-cy="unit-block-dialog-title">
-          {{(loadingUnits.list.length > 1 || currentUnit.codeRequiringTestlets.length) ? currentUnit?.testletLabel : currentUnit?.unitDef?.title}}
-        </mat-card-title>
-        <mat-card-subtitle *ngIf="loadingUnits.list.length > 1">
-          {{'Aufgabenblock wird geladen' | customtext:'booklet_loadingBlock' | async}}
-        </mat-card-subtitle>
-        <mat-card-subtitle *ngIf="loadingUnits.list.length === 1">
-          {{'Aufgabe wird geladen' | customtext:'booklet_loadingUnit' | async}}
-        </mat-card-subtitle>
-        <mat-card-subtitle *ngIf="currentUnit?.unitDef?.locked">
-          {{'Aufgabenzeit ist abgelaufen' | customtext:'booklet_lockedBlock' | async}}
-        </mat-card-subtitle>
-        <mat-card-subtitle *ngIf="currentUnit.codeRequiringTestlets.length">
-          {{'Aufgabenblock ist noch gesperrt' | customtext:'booklet_codeToEnterTitle' | async}}
-        </mat-card-subtitle>
-      </mat-card-header>
+  <ng-container *ngIf="{ list: (unitsLoading$ | async) } as loadingUnits">
+    <div id="waiting-room"  *ngIf="loadingUnits.list.length || currentUnit?.unitDef?.locked || codeRequiringTestlets.length">
+      <mat-card appearance="raised">
+        <mat-card-header>
+          <mat-card-title data-cy="unit-block-dialog-title">
+            {{(loadingUnits.list.length > 1 || currentUnit.codeRequiringTestlets.length) ? currentUnit?.testletLabel : currentUnit?.unitDef?.title}}
+          </mat-card-title>
+          <mat-card-subtitle *ngIf="loadingUnits.list.length > 1">
+            {{'Aufgabenblock wird geladen' | customtext:'booklet_loadingBlock' | async}}
+          </mat-card-subtitle>
+          <mat-card-subtitle *ngIf="loadingUnits.list.length === 1">
+            {{'Aufgabe wird geladen' | customtext:'booklet_loadingUnit' | async}}
+          </mat-card-subtitle>
+          <mat-card-subtitle *ngIf="currentUnit?.unitDef?.locked">
+            {{'Aufgabenzeit ist abgelaufen' | customtext:'booklet_lockedBlock' | async}}
+          </mat-card-subtitle>
+          <mat-card-subtitle *ngIf="currentUnit.codeRequiringTestlets.length">
+            {{'Aufgabenblock ist noch gesperrt' | customtext:'booklet_codeToEnterTitle' | async}}
+          </mat-card-subtitle>
+        </mat-card-header>
 
-        <mat-card-content *ngIf="codeRequiringTestlets.length">
-          <ng-container *ngFor="let testlet of codeRequiringTestlets">
-            <mat-form-field appearance="outline" style="display: block" >
-              <input
-                matInput
-                type="text"
-                [(ngModel)]="clearCodes[testlet.id]"
-                style="text-transform:uppercase"
-                (keydown)="onKeydownInClearCodeInput($event)"
-                data-cy="unlockUnit"
-                matTooltip="{{codeRequiringTestlets.length > 1 ? testlet.title || ('Block ' + (testlet.sequenceId + 1)) : undefined}}"
+          <mat-card-content *ngIf="codeRequiringTestlets.length">
+            <ng-container *ngFor="let testlet of codeRequiringTestlets">
+              <mat-form-field appearance="outline" style="display: block" >
+                <input
+                  matInput
+                  type="text"
+                  [(ngModel)]="clearCodes[testlet.id]"
+                  style="text-transform:uppercase"
+                  (keydown)="onKeydownInClearCodeInput($event)"
+                  data-cy="unlockUnit"
+                  matTooltip="{{codeRequiringTestlets.length > 1 ? testlet.title || ('Block ' + (testlet.sequenceId + 1)) : undefined}}"
+                >
+              </mat-form-field>
+              <tc-alert
+                level="info"
+                *ngIf="!testlet.codePrompt"
+                customtext="booklet_codeToEnterPrompt"
+                text="Bitte Freigabewort eingeben!"
+              ></tc-alert>
+              <tc-alert
+                level="info"
+                *ngIf="testlet.codePrompt"
+                [text]="testlet.codePrompt"
+              ></tc-alert>
+              <tc-alert level="warning" customtext="booklet_codeToEnterWarning"></tc-alert>
+            </ng-container>
+          </mat-card-content>
+          <mat-card-content>
+            <ng-container *ngFor="let loading of loadingUnits.list; let index = index">
+              <mat-progress-bar
+                color="primary"
+                [mode]="({'UNKNOWN': 'indeterminate', 'PENDING': 'query'})[loading.progress] || 'determinate'"
+                [value]="loading.progress"
               >
-            </mat-form-field>
-            <tc-alert
-              level="info"
-              *ngIf="!testlet.codePrompt"
-              customtext="booklet_codeToEnterPrompt"
-              text="Bitte Freigabewort eingeben!"
-            ></tc-alert>
-            <tc-alert
-              level="info"
-              *ngIf="testlet.codePrompt"
-              [text]="testlet.codePrompt"
-            ></tc-alert>
-            <tc-alert level="warning" customtext="booklet_codeToEnterWarning"></tc-alert>
+              </mat-progress-bar>
+            <p class="progress-bar-sub-text">
+              {{unitsToLoadLabels[index]}}
+              <ng-container [ngSwitch]="loading.progress">
+                <span *ngSwitchCase="'UNKNOWN'">
+                  ({{'wird geladen' | customtext:'booklet_unitLoadingUnknownProgress' | async}})
+                </span>
+                <span *ngSwitchCase="'PENDING'">
+                  ({{'in der Warteschleife' | customtext:'booklet_unitLoadingPending' | async}})
+                </span>
+                <span *ngSwitchDefault>
+                  ({{loading.progress}}% {{'geladen' | customtext:'booklet_unitLoading' | async}})
+                </span>
+              </ng-container>
+            </p>
           </ng-container>
         </mat-card-content>
-        <mat-card-content>
-          <ng-container *ngFor="let loading of loadingUnits.list; let index = index">
-            <mat-progress-bar
-              color="primary"
-              [mode]="({'UNKNOWN': 'indeterminate', 'PENDING': 'query'})[loading.progress] || 'determinate'"
-              [value]="loading.progress"
-            >
-            </mat-progress-bar>
-          <p class="progress-bar-sub-text">
-            {{unitsToLoadLabels[index]}}
-            <ng-container [ngSwitch]="loading.progress">
-              <span *ngSwitchCase="'UNKNOWN'">
-                ({{'wird geladen' | customtext:'booklet_unitLoadingUnknownProgress' | async}})
-              </span>
-              <span *ngSwitchCase="'PENDING'">
-                ({{'in der Warteschleife' | customtext:'booklet_unitLoadingPending' | async}})
-              </span>
-              <span *ngSwitchDefault>
-                ({{loading.progress}}% {{'geladen' | customtext:'booklet_unitLoading' | async}})
-              </span>
-            </ng-container>
-          </p>
-        </ng-container>
-      </mat-card-content>
-      <mat-card-actions [style.justify-content]="'space-between'">
-        <button
-          *ngIf="codeRequiringTestlets.length"
-          mat-raised-button
-          color="primary"
-          [disabled]="(clearCodes | keyvalue)?.length < codeRequiringTestlets.length"
-          (click)="verifyCodes()"
-          data-cy="unit-block-dialog-submit"
-        >
-          OK
-        </button>
-        <button
-          *ngIf="tcs.bookletConfig.unit_navibuttons === 'OFF'"
-          mat-raised-button
-          [disabled]="tcs.currentUnitSequenceId === 0"
-          (click)="tcs.setUnitNavigationRequest(unitNavigationTarget.PREVIOUS)" matTooltip="Zurück"
-        >
-          <i class="material-icons">chevron_left</i>
-        </button>
-        <button
-          *ngIf="tcs.bookletConfig.unit_navibuttons === 'OFF'"
-          mat-raised-button
-          [disabled]="tcs.currentUnitSequenceId >= tcs.allUnitIds.length"
-          (click)="tcs.setUnitNavigationRequest(unitNavigationTarget.NEXT)" matTooltip="Weiter"
-        >
-          <i class="material-icons">chevron_right</i>
-        </button>
-      </mat-card-actions>
-    </mat-card>
+        <mat-card-actions [style.justify-content]="'space-between'">
+          <button
+            *ngIf="codeRequiringTestlets.length"
+            mat-raised-button
+            color="primary"
+            [disabled]="(clearCodes | keyvalue)?.length < codeRequiringTestlets.length"
+            (click)="verifyCodes()"
+            data-cy="unit-block-dialog-submit"
+          >
+            OK
+          </button>
+          <button
+            *ngIf="tcs.bookletConfig.unit_navibuttons === 'OFF'"
+            mat-raised-button
+            [disabled]="tcs.currentUnitSequenceId === 0"
+            (click)="tcs.setUnitNavigationRequest(unitNavigationTarget.PREVIOUS)" matTooltip="Zurück"
+          >
+            <i class="material-icons">chevron_left</i>
+          </button>
+          <button
+            *ngIf="tcs.bookletConfig.unit_navibuttons === 'OFF'"
+            mat-raised-button
+            [disabled]="tcs.currentUnitSequenceId >= tcs.allUnitIds.length"
+            (click)="tcs.setUnitNavigationRequest(unitNavigationTarget.NEXT)" matTooltip="Weiter"
+          >
+            <i class="material-icons">chevron_right</i>
+          </button>
+        </mat-card-actions>
+      </mat-card>
+    </div>
+  </ng-container>
+
+
+  <div *ngIf="tcs.bookletConfig.page_navibuttons === 'SEPARATE_BOTTOM' &&
+              pageList && pageList.length && (pageList.length > 1)"
+       class="page-navigation">
+    <div [style.float]="'right'" [style.padding-top.px]="4" [style.padding-right.px]="15">
+      <tc-page-nav [pages]="pageList" [currentPageIndex]="currentPageIndex"
+                   (navToPage)="gotoPage($event)"
+                   (navPrevious)="gotoPreviousPage()"
+                   (navNext)="gotoNextPage()">
+      </tc-page-nav>
+    </div>
   </div>
-</ng-container>
-
-
-<div *ngIf="tcs.bookletConfig.page_navibuttons === 'SEPARATE_BOTTOM' &&
-          knownPages && knownPages.length && (knownPages.length > 1)"
-   class="page-navigation">
-<div [style.float]="'right'" [style.padding-top.px]="4" [style.padding-right.px]="15">
-  <span [style.color]="'white'" [style.padding-right.px]="8">
-    {{ ''  | customtext:'login_pagesNaviPrompt' | async}}
-  </span>
-
-  <mat-button-toggle-group>
-    <mat-button-toggle [disabled]="currentPageIndex <= 0"
-                       (click)="gotoPage(knownPages[currentPageIndex - 1].id);">
-      <i class="material-icons">chevron_left</i>
-    </mat-button-toggle>
-    <mat-button-toggle *ngFor="let page of knownPages; let index = index"
-                       [matTooltip]="page.label"
-                       [checked]="currentPageIndex === index"
-                       [attr.data-cy]="'page-navigation-' + index"
-                       (click)="gotoPage(page.id)">
-      {{ index + 1 }}
-    </mat-button-toggle>
-    <mat-button-toggle [disabled]="currentPageIndex >= knownPages.length - 1"
-                       (click)="gotoPage(knownPages[currentPageIndex + 1].id);">
-      <i class="material-icons">chevron_right</i>
-    </mat-button-toggle>
-  </mat-button-toggle-group>
-</div>
-</div>
 </div>

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -109,25 +109,6 @@ div.logo img {
   z-index: 1000;
 }
 
-/* page navigation */
-/* TODO(mdc-migration): The following rule targets internal classes of button that may no longer apply for the MDC version. */
-mat-button-toggle-group {
-  flex-wrap: nowrap !important
-}
-
-/* TODO(mdc-migration): The following rule targets internal classes of button that may no longer apply for the MDC version. */
-.mat-button-toggle-appearance-standard .mat-button-toggle-label-content,
-.mat-button-toggle-appearance-standard .mat-button-toggle-label-content {
-  line-height: 36px !important;
-}
-
-/* TODO(mdc-migration): The following rule targets internal classes of button that may no longer apply for the MDC version. */
-.mat-button-toggle-checked .mat-button-toggle-button,
-.mat-button-toggle-checked .mat-button-toggle-button {
-  background-color: var(--accent);
-}
-
-
 .flex-row {
   display: flex;
   flex-direction: row;


### PR DESCRIPTION
Use the same paging component in the syscheck and the normal unit host.

Change the way page data is handled: The Verona API serves pages as a  dictionary with page number/indexes as key and page labels as value.  This is now changed to a simple array of labels - the papge index is  implicit. At some point the API will change this but for now it is  transformed in the frontend code.

- Refactor page variables: knownPages is now pageList with simplified  type
- Some small UI and code formatting improvements