### PR TITLE
[env] Add TLS_ENABLED switch back to prod setup

### DIFF
--- a/dist-src/.env
+++ b/dist-src/.env
@@ -21,3 +21,5 @@ CACHE_SERVICE_INCLUDE_FILES=false
 # Network
 ### MTU Setting. Default is 1500, but Openstack actually uses 1442
 DOCKER_DAEMON_MTU=1442
+
+TLS_ENABLED=on

--- a/dist-src/Makefile
+++ b/dist-src/Makefile
@@ -1,20 +1,52 @@
+include .env
+
 run:
-	docker compose -f docker-compose.yml -f docker-compose.prod.yml up --abort-on-container-exit
+	@if [ "$(TLS_ENABLED)" = "on" ] || [ "$(TLS_ENABLED)" = "yes" ] || [ "$(TLS_ENABLED)" = "true" ]; then\
+		echo "Starting with TLS";\
+		docker compose -f docker-compose.yml -f docker-compose.prod.tls.yml up --abort-on-container-exit;\
+	else\
+		echo "Starting without TLS";\
+		docker compose -f docker-compose.yml -f docker-compose.prod.yml up --abort-on-container-exit;\
+	fi
 
 run-detached:
-	docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d
+	@if [ "$(TLS_ENABLED)" = "on" ] || [ "$(TLS_ENABLED)" = "yes" ] || [ "$(TLS_ENABLED)" = "true" ]; then\
+		docker compose -f docker-compose.yml -f docker-compose.prod.yml -f docker-compose.prod.tls.yml up -d;\
+	else\
+		docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d;\
+	fi
 
 stop:
-	docker compose -f docker-compose.yml -f docker-compose.prod.yml stop
+	@if [ "$(TLS_ENABLED)" = "on" ] || [ "$(TLS_ENABLED)" = "yes" ] || [ "$(TLS_ENABLED)" = "true" ]; then\
+		docker compose -f docker-compose.yml -f docker-compose.prod.yml -f docker-compose.prod.tls.yml stop;\
+	else\
+		docker compose -f docker-compose.yml -f docker-compose.prod.yml stop;\
+	fi
 
 down:
-	docker compose -f docker-compose.yml -f docker-compose.prod.yml down
+	@if [ "$(TLS_ENABLED)" = "on" ] || [ "$(TLS_ENABLED)" = "yes" ] || [ "$(TLS_ENABLED)" = "true" ]; then\
+		docker compose -f docker-compose.yml -f docker-compose.prod.yml -f docker-compose.prod.tls.yml down;\
+	else\
+		docker compose -f docker-compose.yml -f docker-compose.prod.yml down;\
+	fi
 
 pull:
-	docker compose -f docker-compose.yml -f docker-compose.prod.yml pull
+	@if [ "$(TLS_ENABLED)" = "on" ] || [ "$(TLS_ENABLED)" = "yes" ] || [ "$(TLS_ENABLED)" = "true" ]; then\
+		docker compose -f docker-compose.yml -f docker-compose.prod.yml -f docker-compose.prod.tls.yml pull;\
+	else\
+		docker compose -f docker-compose.yml -f docker-compose.prod.yml pull;\
+	fi
 
 restart:
-	docker compose -f docker-compose.yml -f docker-compose.prod.yml restart
+	@if [ "$(TLS_ENABLED)" = "on" ] || [ "$(TLS_ENABLED)" = "yes" ] || [ "$(TLS_ENABLED)" = "true" ]; then\
+		docker compose -f docker-compose.yml -f docker-compose.prod.yml -f docker-compose.prod.tls.yml restart;\
+	else\
+		docker compose -f docker-compose.yml -f docker-compose.prod.yml restart;\
+	fi
 
 logs:
-	docker compose -f docker-compose.yml -f docker-compose.prod.yml logs $(service)
+	@if [ "$(TLS_ENABLED)" = "on" ] || [ "$(TLS_ENABLED)" = "yes" ] || [ "$(TLS_ENABLED)" = "true" ]; then\
+		docker compose -f docker-compose.yml -f docker-compose.prod.yml -f docker-compose.prod.tls.yml logs $(service);\
+	else\
+		docker compose -f docker-compose.yml -f docker-compose.prod.yml logs $(service);\
+	fi

--- a/dist-src/docker-compose.prod.tls.yml
+++ b/dist-src/docker-compose.prod.tls.yml
@@ -1,0 +1,64 @@
+#  Compose file for production environment. Images are NOT locally built but
+#  downloaded from Docker-Hub. This is the non-TLS variant using unencrypted
+#  communication.
+version: '3.9'
+
+services:
+  traefik:
+    command:
+      - "--providers.docker=true"
+      - "--providers.docker.exposedbydefault=false"
+      - "--entrypoints.web.address=:80"
+      - "--entrypoints.web.http.redirections.entryPoint.to=websecure"
+      - "--entrypoints.web.http.redirections.entryPoint.scheme=https"
+      - "--entrypoints.websecure.address=:443"
+      - "--entrypoints.websecure.http.tls.options=default@file"
+      - "--providers.file.filename=/tls-config.yml"
+    ports:
+      - "${TLS_PORT}:443"
+    volumes:
+      - ./config/certs/:/certs/
+      - ./config/tls-config.yml:/tls-config.yml
+
+  testcenter-db:
+    image: iqbberlin/testcenter-db:${VERSION}
+    command:
+      - --log_error_verbosity=1
+
+  testcenter-backend:
+    image: iqbberlin/testcenter-backend:${VERSION}
+    labels:
+      - "traefik.http.routers.testcenter-backend.tls=true"
+      - "traefik.http.middlewares.tls-security-headers-backend.headers.stsSeconds=31536000"
+      - "traefik.http.middlewares.tls-security-headers-backend.headers.stsIncludeSubdomains=true"
+      - "traefik.http.routers.testcenter-backend.middlewares=testcenter-backend-stripprefix, security-headers-backend, tls-security-headers-backend"
+    volumes:
+      - testcenter_backend_vo_data:/var/www/data
+
+  testcenter-frontend:
+    image: iqbberlin/testcenter-frontend:${VERSION}
+    volumes:
+      - ./config/nginx.conf:/etc/nginx/conf.d/default.conf
+    labels:
+      - "traefik.http.routers.testcenter-frontend.tls=true"
+      - "traefik.http.middlewares.tls-security-headers-frontend.headers.stsSeconds=31536000"
+      - "traefik.http.middlewares.tls-security-headers-frontend.headers.stsIncludeSubdomains=true"
+      - "traefik.http.middlewares.stripwww-fe.redirectregex.regex=^http(s?)://www.${HOSTNAME}/(.*)"
+      - "traefik.http.middlewares.stripwww-fe.redirectregex.replacement=http$${1}://${HOSTNAME}/$${2}"
+      - "traefik.http.routers.testcenter-frontend.middlewares=security-headers-frontend, tls-security-headers-frontend, stripwww-fe"
+
+  testcenter-broadcasting-service:
+    image: iqbberlin/testcenter-broadcasting-service:${VERSION}
+    labels:
+      - "traefik.http.routers.testcenter-broadcasting-service.tls=true"
+      - "traefik.http.middlewares.tls-security-headers-bs.headers.stsSeconds=31536000"
+      - "traefik.http.middlewares.tls-security-headers-bs.headers.stsIncludeSubdomains=true"
+      - "traefik.http.routers.testcenter-broadcasting-service.middlewares=testcenter-broadcasting-service-stripprefix, security-headers-bs, tls-security-headers-bs"
+
+  testcenter-file-service:
+    image: iqbberlin/testcenter-file-service:${VERSION}
+    labels:
+      - "traefik.http.routers.testcenter-file-service.tls=true"
+      - "traefik.http.middlewares.tls-security-headers-fs.headers.stsSeconds=31536000"
+      - "traefik.http.middlewares.tls-security-headers-fs.headers.stsIncludeSubdomains=true"
+      - "traefik.http.routers.testcenter-file-service.middlewares=testcenter-file-service-stripprefix, security-headers-fs, tls-security-headers-fs"

--- a/dist-src/docker-compose.prod.yml
+++ b/dist-src/docker-compose.prod.yml
@@ -4,29 +4,13 @@
 version: '3.9'
 
 services:
-  traefik:
+  testcenter-db:
+    image: iqbberlin/testcenter-db:${VERSION}
     command:
-      - "--providers.docker=true"
-      - "--providers.docker.exposedbydefault=false"
-      - "--entrypoints.web.address=:80"
-      - "--entrypoints.web.http.redirections.entryPoint.to=websecure"
-      - "--entrypoints.web.http.redirections.entryPoint.scheme=https"
-      - "--entrypoints.websecure.address=:443"
-      - "--entrypoints.websecure.http.tls.options=default@file"
-      - "--providers.file.filename=/tls-config.yml"
-    ports:
-      - "${TLS_PORT}:443"
-    volumes:
-      - ./config/certs/:/certs/
-      - ./config/tls-config.yml:/tls-config.yml
+      - --log_error_verbosity=1
 
   testcenter-backend:
     image: iqbberlin/testcenter-backend:${VERSION}
-    labels:
-      - "traefik.http.routers.testcenter-backend.tls=true"
-      - "traefik.http.middlewares.tls-security-headers-backend.headers.stsSeconds=31536000"
-      - "traefik.http.middlewares.tls-security-headers-backend.headers.stsIncludeSubdomains=true"
-      - "traefik.http.routers.testcenter-backend.middlewares=testcenter-backend-stripprefix, security-headers-backend, tls-security-headers-backend"
     volumes:
       - testcenter_backend_vo_data:/var/www/data
 
@@ -34,31 +18,9 @@ services:
     image: iqbberlin/testcenter-frontend:${VERSION}
     volumes:
       - ./config/nginx.conf:/etc/nginx/conf.d/default.conf
-    labels:
-      - "traefik.http.routers.testcenter-frontend.tls=true"
-      - "traefik.http.middlewares.tls-security-headers-frontend.headers.stsSeconds=31536000"
-      - "traefik.http.middlewares.tls-security-headers-frontend.headers.stsIncludeSubdomains=true"
-      - "traefik.http.middlewares.stripwww-fe.redirectregex.regex=^http(s?)://www.${HOSTNAME}/(.*)"
-      - "traefik.http.middlewares.stripwww-fe.redirectregex.replacement=http$${1}://${HOSTNAME}/$${2}"
-      - "traefik.http.routers.testcenter-frontend.middlewares=security-headers-frontend, tls-security-headers-frontend, stripwww-fe"
 
   testcenter-broadcasting-service:
     image: iqbberlin/testcenter-broadcasting-service:${VERSION}
-    labels:
-      - "traefik.http.routers.testcenter-broadcasting-service.tls=true"
-      - "traefik.http.middlewares.tls-security-headers-bs.headers.stsSeconds=31536000"
-      - "traefik.http.middlewares.tls-security-headers-bs.headers.stsIncludeSubdomains=true"
-      - "traefik.http.routers.testcenter-broadcasting-service.middlewares=testcenter-broadcasting-service-stripprefix, security-headers-bs, tls-security-headers-bs"
 
   testcenter-file-service:
     image: iqbberlin/testcenter-file-service:${VERSION}
-    labels:
-      - "traefik.http.routers.testcenter-file-service.tls=true"
-      - "traefik.http.middlewares.tls-security-headers-fs.headers.stsSeconds=31536000"
-      - "traefik.http.middlewares.tls-security-headers-fs.headers.stsIncludeSubdomains=true"
-      - "traefik.http.routers.testcenter-file-service.middlewares=testcenter-file-service-stripprefix, security-headers-fs, tls-security-headers-fs"
-
-  testcenter-db:
-    image: iqbberlin/testcenter-db:${VERSION}
-    command:
-      - --log_error_verbosity=1

--- a/dist-src/install.sh
+++ b/dist-src/install.sh
@@ -49,6 +49,7 @@ download_files() {
   wget -nv -O Makefile https://raw.githubusercontent.com/${REPO_URL}/${VERSION}/dist-src/Makefile
   wget -nv -O docker-compose.yml https://raw.githubusercontent.com/${REPO_URL}/${VERSION}/docker/docker-compose.yml
   wget -nv -O docker-compose.prod.yml https://raw.githubusercontent.com/${REPO_URL}/${VERSION}/dist-src/docker-compose.prod.yml
+  wget -nv -O docker-compose.prod.yml https://raw.githubusercontent.com/${REPO_URL}/${VERSION}/dist-src/docker-compose.prod.tls.yml
   wget -nv -O config/tls-config.yml https://raw.githubusercontent.com/${REPO_URL}/${VERSION}/dist-src/tls-config.yml
   wget -nv -O config/nginx.conf https://raw.githubusercontent.com/${REPO_URL}/${VERSION}/frontend/config/nginx.conf
   wget -nv -O update.sh https://raw.githubusercontent.com/${REPO_URL}/${VERSION}/dist-src/update.sh

--- a/dist-src/patches/next.sh
+++ b/dist-src/patches/next.sh
@@ -1,0 +1,11 @@
+# Change base compose file for 'www-fix'
+wget -nv -O docker-compose.yml https://raw.githubusercontent.com/${REPO_URL}/${VERSION}/docker/docker-compose.yml
+
+# Change compose file for non-tls setup
+wget -nv -O docker-compose.prod.yml https://raw.githubusercontent.com/${REPO_URL}/${VERSION}/dist-src/docker-compose.prod.yml
+
+# Download additional compose file
+wget -nv -O docker-compose.prod.yml https://raw.githubusercontent.com/${REPO_URL}/${VERSION}/dist-src/docker-compose.prod.tls.yml
+
+# Change Makefile for non-tls setup
+wget -nv -O Makefile https://raw.githubusercontent.com/${REPO_URL}/${VERSION}/dist-src/Makefile

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -120,7 +120,9 @@ services:
       - "traefik.http.middlewares.security-headers-frontend.headers.contentTypeNosniff=true"
       - "traefik.http.middlewares.security-headers-frontend.headers.customFrameOptionsValue=SAMEORIGIN"
       - "traefik.http.middlewares.security-headers-frontend.headers.referrerPolicy=no-referrer"
-      - "traefik.http.routers.testcenter-frontend.middlewares=security-headers-frontend"
+      - "traefik.http.middlewares.stripwww-fe.redirectregex.regex=^http(s?)://www.${HOSTNAME}/(.*)"
+      - "traefik.http.middlewares.stripwww-fe.redirectregex.replacement=http$${1}://${HOSTNAME}/$${2}"
+      - "traefik.http.routers.testcenter-frontend.middlewares=security-headers-frontend, stripwww-fe"
     networks:
       testcenter:
 


### PR DESCRIPTION
There are again multiple compose files for prod which stack. The switch  (TLS_ENABLED) is used in 
the Makefile, which calls the correct compose files.

Patchdateiname muss angepasst werden.