### PR TITLE
fe/remove pw.focus from login

### DIFF
--- a/frontend/src/app/app-root/login/login.component.html
+++ b/frontend/src/app/app-root/login/login.component.html
@@ -13,7 +13,7 @@
       <mat-card-content *ngIf="mainDataService.appConfig">
         <mat-form-field appearance="outline">
           <mat-label>Anmeldename</mat-label>
-          <input matInput formControlName="name" (keyup.enter)="pw.focus()" (keyup)="clearWarning()">
+          <input matInput formControlName="name">
         </mat-form-field>
         <mat-form-field appearance="outline">
           <mat-label>Kennwort</mat-label>


### PR DESCRIPTION
Resolves #453.

Das hat sich folgendermaßen bei mir verhalten:
Wenn das Namensfeld leer war bzw der eingegebene Name zu kurz, dann wurd bei Enter das Passwortfeld fokussiert.
Wenn der eingebene Name lang genug (>= 3 Zeichen) war, dann wurde das Formular abgeschickt (wahrscheinlich für passwortlose Logins).

Ich habe jetzt keinen Grund gesehen, dass Passwortfeld zu fokussieren wenn der Name keine gültige Länge hat, deswegen würde ich das einfach entfernen.
Falls es doch eine spezifische Anforderung dafür gab, dann gib gerne Bescheid.