### PR TITLE
fe: Restore support older (pre Verona4) Players

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,11 @@
 layout: default
 ---
 
+## [next]
+### Bugfixes
+* Alte Verona3-Player, die nicht standardmäßig `StateReportPolicy` auf `eager` gesetzt haben, funktionieren nun wieder
+  korrekt. Dies betrifft z. B. den Aspect-Player.
+
 ## 15.1.4
 ### Bugfixes
 * Fehler der in ganz neuen (123+) Chrome-based Browsern auftritt behoben: Wenn man in das Eingabefeld für Namen oder

--- a/frontend/src/app/test-controller/components/unithost/unithost.component.ts
+++ b/frontend/src/app/test-controller/components/unithost/unithost.component.ts
@@ -402,6 +402,7 @@ export class UnithostComponent implements OnInit, OnDestroy {
       unitNumber: this.currentUnitSequenceId,
       unitTitle: this.tcs.currentUnitTitle,
       unitId: this.currentUnit.unitDef.alias,
+      stateReportPolicy: 'eager', // for pre-verona-4-players which does not report by default
       directDownloadUrl: `${resourceUri}file/${groupToken}/ws_${this.tcs.workspaceId}/Resource`
     };
     if (this.pendingUnitData?.currentPage && (this.tcs.bookletConfig.restore_current_page_on_return === 'ON')) {

--- a/frontend/src/app/test-controller/interfaces/verona.interfaces.ts
+++ b/frontend/src/app/test-controller/interfaces/verona.interfaces.ts
@@ -2,6 +2,8 @@ type Verona2NavigationTarget = 'next' | 'previous' | 'first' | 'last' | 'end';
 
 type Verona2LogPolicy = 'disabled' | 'lean' | 'rich' | 'debug';
 
+type Verona2StateReportPolicy = 'none' | 'eager' | 'on-demand';
+
 type Verona3PagingMode = 'separate' | 'concat-scroll' | 'concat-scroll-snap';
 
 interface Verona2PlayerConfig {
@@ -15,6 +17,7 @@ interface Verona2PlayerConfig {
 interface Verona3PlayerConfig extends Verona2PlayerConfig {
   enabledNavigationTargets: Verona2NavigationTarget[];
   startPage?: string;
+  stateReportPolicy: Verona2StateReportPolicy; // removed in Verona4, but we still need it to support older players
 }
 
 interface Verona4PlayerConfig extends Verona3PlayerConfig {

--- a/frontend/src/app/test-controller/routing/unit-deactivate.guard.ts
+++ b/frontend/src/app/test-controller/routing/unit-deactivate.guard.ts
@@ -82,7 +82,6 @@ export class UnitDeactivateGuard {
     };
     if (
       (checkOnValue[direction].indexOf(unit.unitDef.navigationLeaveRestrictions.presentationComplete) > -1) &&
-      this.tcs.hasUnitPresentationProgress(this.tcs.currentUnitSequenceId) &&
       (this.tcs.getUnitPresentationProgress(this.tcs.currentUnitSequenceId) !== 'complete')
     ) {
       reasons.push('presentationIncomplete');


### PR DESCRIPTION
Some older Players did not have stateReportPolicy: 'eager' by default so we have to set it manually although it does not exist since verona4 anymore.