### PR TITLE
docs: correct type of id in component schema

### DIFF
--- a/docs/api/components.spec.yml
+++ b/docs/api/components.spec.yml
@@ -131,7 +131,7 @@ components:
       type: object
       properties:
         id:
-          type: string
+          type: integer
         type:
           type: string
           description: workspaceAdmin, superAdmin, test, testGroupMonitor or attachmentManager
@@ -159,8 +159,8 @@ components:
       type: object
       properties:
         id:
-          type: string
-          example: "1"
+          type: integer
+          example: 1
         name:
           type: string
           example: "example_workspace"
@@ -194,8 +194,8 @@ components:
           type: string
           example: super
         id:
-          type: string
-          example: "1"
+          type: integer
+          example: 1
         email:
           type: string
           nullable: true
@@ -278,7 +278,7 @@ components:
           $ref: '#/components/schemas/speed_params'
         workspaceId:
           description: on which workspace is this SysCheck?
-          type: number
+          type: integer
 
     speed_params:
       type: object
@@ -320,7 +320,7 @@ components:
       description: definition of a SysCheck-questionaire
       properties:
         id:
-          type: number
+          type: integer
           description: identifier of the question
           example: 1
         type:


### PR DESCRIPTION
Resolves #497.
Neben Workspace ID habe ich außerdem noch die ID von accessObject, user und question_def auf integer gesetzt (waren davor auch String oder number)