### PR TITLE
escape all html tags in error message body

### DIFF
--- a/backend/src/middleware/ErrorHandler.class.php
+++ b/backend/src/middleware/ErrorHandler.class.php
@@ -75,7 +75,7 @@ class ErrorHandler {
       ->withStatus($throwable->getCode(), $throwable->getTitle())
       ->withHeader('Content-Type', 'text/html')
       ->withHeader('Error-ID', $errorUniqueId)
-      ->write($throwable->getMessage() ? $throwable->getMessage() : $throwable->getDescription());
+      ->write(htmlspecialchars($throwable->getMessage() ?: $throwable->getDescription()));
   }
 
   public static function fatal(): void {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,12 @@
 layout: default
 ---
 
+## [next]
+### Sicherheit
+* Der response body aller Fehlermeldungen wird auf html characters escaped. Damit sollten alle Reflected Cross-Site 
+  Scripting Attacken, die aus der Anzeige von unsicheren HTML-Tags entstehen, verhindert werden.
+
+
 ## 15.1.6
 ### neue Features
 * Booklet-XML: Die Zeitbeschränkung erhält einen neuen Schalter `leave`.


### PR DESCRIPTION
resolves #532 

All errors that are not caught, are handled by the ErrorHandler.class.php.

This class outputs the raw body to the client, often times a html-abled web browser. To prevent XSS attacks, all response bodies are html-tag escaped.