### PR TITLE
revamp file upload

### DIFF
--- a/backend/routes.php
+++ b/backend/routes.php
@@ -157,15 +157,15 @@ $app->group('/workspace', function(RouteCollectorProxy $group) {
     ->add(new IsWorkspacePermitted('RO'));
 
   $group->post('/{ws_id}/file', [WorkspaceController::class, 'postFile'])
-    ->add(new IsWorkspaceBlocked())
-    ->add(new IsWorkspacePermitted('RW'));
+    ->add(new IsWorkspacePermitted('RW'))
+    ->add(new IsWorkspaceBlocked());
 
   $group->get('/{ws_id}/files', [WorkspaceController::class, 'getFiles'])
     ->add(new IsWorkspacePermitted('RO'));
 
   $group->delete('/{ws_id}/files', [WorkspaceController::class, 'deleteFiles'])
-    ->add(new IsWorkspaceBlocked())
-    ->add(new IsWorkspacePermitted('RW'));
+    ->add(new IsWorkspacePermitted('RW'))
+    ->add(new IsWorkspaceBlocked());
 
   $group->get('/{ws_id}/report/{type}', [WorkspaceController::class, 'getReport'])
     ->add(new IsWorkspacePermitted('RO'));

--- a/backend/routes.php
+++ b/backend/routes.php
@@ -162,6 +162,8 @@ $app->group('/workspace', function(RouteCollectorProxy $group) {
 
   $group->get('/{ws_id}/files', [WorkspaceController::class, 'getFiles'])
     ->add(new IsWorkspacePermitted('RO'));
+  $group->post('/{ws_id}/files-dependencies', [WorkspaceController::class, 'getFilesWithDependencies'])
+    ->add(new IsWorkspacePermitted('RO'));
 
   $group->delete('/{ws_id}/files', [WorkspaceController::class, 'deleteFiles'])
     ->add(new IsWorkspacePermitted('RW'))

--- a/backend/src/controller/WorkspaceController.class.php
+++ b/backend/src/controller/WorkspaceController.class.php
@@ -151,7 +151,7 @@ class WorkspaceController extends Controller {
     // TODo change the FE and endpoint to accept it with keys
     $fileDigestList = [];
     foreach ($files as $fileType => $fileList) {
-      $fileDigestList[$fileType] = array_values(File::removeWarningForUnusedFiles($fileList));
+      $fileDigestList[$fileType] = array_values(File::removeDeprecatedValues($fileList));
     }
 
     return $response->withJson($fileDigestList);

--- a/backend/src/controller/WorkspaceController.class.php
+++ b/backend/src/controller/WorkspaceController.class.php
@@ -151,7 +151,7 @@ class WorkspaceController extends Controller {
     // TODo change the FE and endpoint to accept it with keys
     $fileDigestList = [];
     foreach ($files as $fileType => $fileList) {
-      $fileDigestList[$fileType] = array_values($fileList);
+      $fileDigestList[$fileType] = array_values(File::removeWarningForUnusedFiles($fileList));
     }
 
     return $response->withJson($fileDigestList);

--- a/backend/src/controller/WorkspaceController.class.php
+++ b/backend/src/controller/WorkspaceController.class.php
@@ -122,9 +122,9 @@ class WorkspaceController extends Controller {
     $workspaceId = (int) $request->getAttribute('ws_id');
     $workspace = new Workspace($workspaceId);
 
-    $uploadedFiles = UploadedFilesHandler::handleUploadedFiles($request, 'fileforvo', $workspace->getWorkspacePath());
+    $filesToImport = UploadedFilesHandler::handleUploadedFiles($request, 'fileforvo', $workspace->getWorkspacePath());
 
-    $importedFiles = $workspace->importUnsortedFiles($uploadedFiles);
+    $importedFiles = $workspace->importUncategorizedFiles($filesToImport);
     $workspace->setWorkspaceHash();
 
     $reports = [];

--- a/backend/src/controller/WorkspaceController.class.php
+++ b/backend/src/controller/WorkspaceController.class.php
@@ -157,6 +157,21 @@ class WorkspaceController extends Controller {
     return $response->withJson($fileDigestList);
   }
 
+  public static function getFilesWithDependencies(Request $request, Response $response) {
+    $workspaceId = (int) $request->getAttribute('ws_id');
+    $names = RequestBodyParser::getRequiredElement($request, 'body');
+
+    $workspace = new Workspace($workspaceId);
+    $files = $workspace->workspaceDAO->getFilesByNames($names);
+
+    $fileDigestList = [];
+    foreach ($files as $fileType => $fileList) {
+      $fileDigestList[$fileType] = array_values(File::removeDeprecatedValues($fileList));
+    }
+
+    return $response->withJson($fileDigestList);
+  }
+
   /** TODO since only allowed files are in the five main folders, a better syntax for the body would suit
    * eg [{"type": "Booklet", "name": "SAMPLE_BOOKLET.XML"}]
    */

--- a/backend/src/dao/WorkspaceDAO.class.php
+++ b/backend/src/dao/WorkspaceDAO.class.php
@@ -482,7 +482,7 @@ class WorkspaceDAO extends DAO {
     return [$unresolvedRelations, $updatedRelations];
   }
 
-  public function getRelatingFiles(File $file): array {
+  public function getDependentFiles(File $file): array {
     // TODO make recursive: a player may affect a unit, that a booklet, and that a testtakers file
 
     $sql = "select

--- a/backend/src/dao/WorkspaceDAO.class.php
+++ b/backend/src/dao/WorkspaceDAO.class.php
@@ -387,7 +387,7 @@ class WorkspaceDAO extends DAO {
     return $this->fetchFiles($sql, $replacements);
   }
 
-  private function fetchFiles($sql, $replacements, bool $getDependencies = false): array {
+  private function fetchFiles($sql, $replacements): array {
     $files = [];
     foreach ($this->_($sql, $replacements, true) as $row) {
       $files[$row['type']] ??= [];

--- a/backend/src/data-collection/FileData.class.php
+++ b/backend/src/data-collection/FileData.class.php
@@ -101,6 +101,10 @@ class FileData extends DataCollectionTypeSafe {
     return $this->validationReport;
   }
 
+  public function setValidationReport(array $report): void {
+    $this->validationReport = $report;
+  }
+
   public function getModificationTime(): int {
     return $this->modificationTime;
   }
@@ -135,5 +139,25 @@ class FileData extends DataCollectionTypeSafe {
 
   public function getVeronaVersion(): string {
     return $this->veronaVersion;
+  }
+
+  /**
+   * @param self[] $fileDigestList
+   * @return self[]
+   */
+  public static function removeWarningForUnusedFiles(array $fileDigestList): array {
+    foreach ($fileDigestList as $file) {
+      $report = $file->getValidationReport();
+      if (isset($report['warning'])) {
+        $report['warning'] = array_values(
+          array_filter(
+            $report['warning'],
+            fn(string $warning) => !str_contains($warning, 'is never used')
+          )
+        );
+        $file->setValidationReport($report);
+      }
+    }
+    return $fileDigestList;
   }
 }

--- a/backend/src/data-collection/FileData.class.php
+++ b/backend/src/data-collection/FileData.class.php
@@ -113,6 +113,10 @@ class FileData extends DataCollectionTypeSafe {
     return $this->contextData;
   }
 
+  public function setContextData(array $contextData): void {
+    $this->contextData = $contextData;
+  }
+
   public function getVeronaModuleType(): string {
     return $this->veronaModuleType;
   }
@@ -145,8 +149,10 @@ class FileData extends DataCollectionTypeSafe {
    * @param self[] $fileDigestList
    * @return self[]
    */
-  public static function removeWarningForUnusedFiles(array $fileDigestList): array {
+  public static function removeDeprecatedValues(array $fileDigestList): array {
     foreach ($fileDigestList as $file) {
+
+      // remove 'unused resource' warning, as this is calculated in FE
       $report = $file->getValidationReport();
       if (isset($report['warning'])) {
         $report['warning'] = array_values(
@@ -156,6 +162,13 @@ class FileData extends DataCollectionTypeSafe {
           )
         );
         $file->setValidationReport($report);
+      }
+
+      // remove totalSize, as this is calculated in FE
+      $contextData = $file->getContextData();
+      if (isset($contextData['totalSize'])) {
+        unset($contextData['totalSize']);
+        $file->setContextData($contextData);
       }
     }
     return $fileDigestList;

--- a/backend/src/data-collection/FileType.enum.php
+++ b/backend/src/data-collection/FileType.enum.php
@@ -1,0 +1,48 @@
+<?php
+/** @noinspection PhpUnhandledExceptionInspection */
+declare(strict_types=1);
+
+enum FileType: string
+{
+  case TESTTAKERS = 'Testtakers';
+  case BOOKLET = 'Booklet';
+  //case SYSTEMCHECK = 'Syscheck';
+  case UNIT = 'Unit';
+  case RESOURCE = 'Resource';
+
+  /** @return string[] */
+  public static function getDependantTypes(self $type): array {
+    $rightDepOnLeft = ['Testtakers', 'Booklet', 'Unit', 'Resource'];
+    $dependantTypes = [];
+
+    $isDependent = false;
+    foreach ($rightDepOnLeft as $dependant) {
+      if ($isDependent) {
+        $dependantTypes[] = $dependant;
+        continue;
+      }
+
+      if ($dependant == $type->value) {
+        $isDependent = true;
+        $dependantTypes[] = $dependant;
+      }
+    }
+
+    return $dependantTypes;
+  }
+
+  /**
+   * @param string[] $types
+   * @return self|null
+   */
+  public static function getTopRootDependentType(array $types): ?self {
+    $rightDepOnLeft = ['Testtakers', 'Booklet', 'Unit', 'Resource'];
+
+    foreach ($rightDepOnLeft as $topRoot) {
+      foreach ($types as $type) {
+        if ($type == $topRoot) return self::tryFrom($type);
+      }
+    }
+    return null;
+  }
+}

--- a/backend/src/data-collection/FileType.enum.php
+++ b/backend/src/data-collection/FileType.enum.php
@@ -4,15 +4,24 @@ declare(strict_types=1);
 
 enum FileType: string
 {
+  case SYSTEMCHECK = 'SysCheck';
   case TESTTAKERS = 'Testtakers';
   case BOOKLET = 'Booklet';
-  case SYSTEMCHECK = 'SysCheck';
   case UNIT = 'Unit';
   case RESOURCE = 'Resource';
 
-  /** @return string[] */
+  /**
+   * Returns the types of the input type and its dependencies in the correct order.
+   * @return string[]
+   */
   public static function getDependenciesOfType(self $dependantType): array {
-    $leftDepOnRight = ['Testtakers', 'Booklet', 'Unit', 'Resource'];
+    $leftDepOnRight = [
+      self::SYSTEMCHECK->value,
+      self::TESTTAKERS->value,
+      self::BOOKLET->value,
+      self::UNIT->value,
+      self::RESOURCE->value,
+    ];
     $dependencies = [];
 
     $dependencyStartsHere = false;
@@ -29,20 +38,5 @@ enum FileType: string
     }
 
     return $dependencies;
-  }
-
-  /**
-   * @param string[] $types
-   * @return self|null
-   */
-  public static function getTopRootDependentType(array $types): ?self {
-    $rightDepOnLeft = array_map(fn(self $type) => $type->value, self::cases());
-
-    foreach ($rightDepOnLeft as $topRoot) {
-      foreach ($types as $type) {
-        if ($type == $topRoot) return self::tryFrom($type);
-      }
-    }
-    return null;
   }
 }

--- a/backend/src/data-collection/FileType.enum.php
+++ b/backend/src/data-collection/FileType.enum.php
@@ -6,29 +6,29 @@ enum FileType: string
 {
   case TESTTAKERS = 'Testtakers';
   case BOOKLET = 'Booklet';
-  //case SYSTEMCHECK = 'Syscheck';
+  case SYSTEMCHECK = 'SysCheck';
   case UNIT = 'Unit';
   case RESOURCE = 'Resource';
 
   /** @return string[] */
-  public static function getDependantTypes(self $type): array {
-    $rightDepOnLeft = ['Testtakers', 'Booklet', 'Unit', 'Resource'];
-    $dependantTypes = [];
+  public static function getDependenciesOfType(self $dependantType): array {
+    $leftDepOnRight = ['Testtakers', 'Booklet', 'Unit', 'Resource'];
+    $dependencies = [];
 
-    $isDependent = false;
-    foreach ($rightDepOnLeft as $dependant) {
-      if ($isDependent) {
-        $dependantTypes[] = $dependant;
-        continue;
+    $dependencyStartsHere = false;
+    foreach ($leftDepOnRight as $dependency) {
+      if ($dependencyStartsHere) {
+        $dependencies[] = $dependency;
+        break;
       }
 
-      if ($dependant == $type->value) {
-        $isDependent = true;
-        $dependantTypes[] = $dependant;
+      if ($dependency == $dependantType->value) {
+        $dependencyStartsHere = true;
+        $dependencies[] = $dependency;
       }
     }
 
-    return $dependantTypes;
+    return $dependencies;
   }
 
   /**
@@ -36,7 +36,7 @@ enum FileType: string
    * @return self|null
    */
   public static function getTopRootDependentType(array $types): ?self {
-    $rightDepOnLeft = ['Testtakers', 'Booklet', 'Unit', 'Resource'];
+    $rightDepOnLeft = array_map(fn(self $type) => $type->value, self::cases());
 
     foreach ($rightDepOnLeft as $topRoot) {
       foreach ($types as $type) {

--- a/backend/src/files/File.class.php
+++ b/backend/src/files/File.class.php
@@ -24,6 +24,7 @@ class File extends FileData {
     };
   }
 
+  /** For use in testing classes */
   static function fromString(string $fileContent, string $fileName = 'virtual_file'): File {
     $file = new static(new FileData($fileName));
     $file->content = $fileContent;

--- a/backend/src/files/File.class.php
+++ b/backend/src/files/File.class.php
@@ -167,6 +167,7 @@ class File extends FileData {
       'type' => $this->type,
       'id' => $this->id,
       'report' => $this->validationReport,
+      'dependencies' => $this->relations,
       'info' => array_merge($info, $this->getContextData()
       ),
     ];

--- a/backend/src/files/File.class.php
+++ b/backend/src/files/File.class.php
@@ -33,7 +33,7 @@ class File extends FileData {
   }
 
   // TODO unit-test
-  private static function determineType(string $path): string {
+  public static function determineType(string $path): string {
     if (strtoupper(substr($path, -4)) == '.XML') {
       $asGenericXmlFile = new XMLFile($path);
       if (!in_array($asGenericXmlFile->rootTagName, XMLFile::knownRootTags)) {

--- a/backend/src/files/XMLFileBooklet.class.php
+++ b/backend/src/files/XMLFileBooklet.class.php
@@ -11,7 +11,6 @@ class XMLFileBooklet extends XMLFile {
     parent::crossValidate($workspaceCache);
 
     $bookletPlayers = [];
-    $this->contextData['totalSize'] = $this->getSize();
 
     foreach ($this->getUnitIds() as $unitId) {
       $unit = $workspaceCache->getUnit($unitId);
@@ -23,8 +22,6 @@ class XMLFileBooklet extends XMLFile {
 
       $this->addRelation(new FileRelation($unit->getType(), $unitId, FileRelationshipType::containsUnit, $unit));
 
-      $this->contextData['totalSize'] += $unit->getTotalSize();
-
       $playerFile = $unit->getPlayerIfExists($workspaceCache);
 
       if (!$playerFile) {
@@ -32,7 +29,6 @@ class XMLFileBooklet extends XMLFile {
       }
 
       if ($playerFile and !in_array($playerFile->getId(), $bookletPlayers)) {
-        $this->contextData['totalSize'] += $playerFile->getSize();
         $bookletPlayers[] = $playerFile->getId();
       }
     }

--- a/backend/src/files/XMLFileBooklet.class.php
+++ b/backend/src/files/XMLFileBooklet.class.php
@@ -10,7 +10,6 @@ class XMLFileBooklet extends XMLFile {
   public function crossValidate(WorkspaceCache $workspaceCache): void {
     parent::crossValidate($workspaceCache);
 
-    $bookletPlayers = [];
 
     foreach ($this->getUnitIds() as $unitId) {
       $unit = $workspaceCache->getUnit($unitId);
@@ -20,17 +19,13 @@ class XMLFileBooklet extends XMLFile {
         continue;
       }
 
+      if (!$unit->isValid()) {
+        $this->report('error', "Unit `$unitId` has an error");
+        continue;
+      }
+
       $this->addRelation(new FileRelation($unit->getType(), $unitId, FileRelationshipType::containsUnit, $unit));
 
-      $playerFile = $unit->getPlayerIfExists($workspaceCache);
-
-      if (!$playerFile) {
-        $this->report('error', "No suitable version of Player found (Unit `$unitId`).");
-      }
-
-      if ($playerFile and !in_array($playerFile->getId(), $bookletPlayers)) {
-        $bookletPlayers[] = $playerFile->getId();
-      }
     }
   }
 

--- a/backend/src/files/XMLFileTesttakers.class.php
+++ b/backend/src/files/XMLFileTesttakers.class.php
@@ -1,4 +1,5 @@
 <?php
+
 /** @noinspection PhpUnhandledExceptionInspection */
 declare(strict_types=1);
 
@@ -29,13 +30,18 @@ class XMLFileTesttakers extends XMLFile {
       foreach ($booklets as $bookletId) {
         $booklet = $validator->getBooklet($bookletId);
 
-        if ($booklet != null) {
-          $this->addRelation(new FileRelation($booklet->getType(), $bookletId, FileRelationshipType::hasBooklet, $booklet));
+        if (!$booklet) {
+          $this->report('error', "Booklet `$bookletId` not found for login `{$testtaker->getName()}`");
+          continue;
         }
 
-        if (!$booklet or !$booklet->isValid()) {
-          $this->report('error', "Booklet `$bookletId` not found for login `{$testtaker->getName()}`");
+        if (!$booklet->isValid()) {
+          $this->report('error', "Booklet `$bookletId` has an error for login `{$testtaker->getName()}`");
+          continue;
         }
+
+        $this->addRelation(new FileRelation($booklet->getType(), $bookletId, FileRelationshipType::hasBooklet, $booklet));
+
       }
     }
   }

--- a/backend/src/files/XMLFileUnit.class.php
+++ b/backend/src/files/XMLFileUnit.class.php
@@ -40,8 +40,6 @@ class XMLFileUnit extends XMLFile {
   }
 
   private function checkIfResourcesExist(WorkspaceCache $validator): void {
-    $this->contextData['totalSize'] = $this->size;
-
     $definitionRef = $this->getDefinitionRef();
 
     $resources = $this->readPlayerDependencies();
@@ -52,21 +50,16 @@ class XMLFileUnit extends XMLFile {
 
     foreach ($resources as $key => $resourceName) {
       $resourceId = strtoupper($resourceName);
-      $resource = $validator->getResource($resourceId, false);
+      $resource = $validator->getResource($resourceId);
 
       if ($resource != null) {
         $relationshipType = ($key === 'definition') ? FileRelationshipType::isDefinedBy : FileRelationshipType::usesPlayerResource;
         $this->addRelation(new FileRelation($resource->getType(), $resourceName, $relationshipType, $resource));
-        $this->contextData['totalSize'] += $resource->getSize();
 
       } else {
         $this->report('error', "Resource `$resourceName` not found");
       }
     }
-  }
-
-  public function getTotalSize(): int {
-    return $this->contextData['totalSize'];
   }
 
   public function readPlayerId(): string {

--- a/backend/src/helper/CLI.class.php
+++ b/backend/src/helper/CLI.class.php
@@ -98,39 +98,39 @@ class CLI {
     }
   }
 
-  static function p(string $text): void {
-    echo "\n$text";
+  static function p(mixed $text): void {
+    echo "\n" . print_r($text, true);
   }
 
-  static function h1(string $text): void {
-    CLI::printColored($text, "Blue", "Grey", true);
+  static function h1(mixed $text): void {
+    CLI::printColored(print_r($text, true), "Blue", "Grey", true);
   }
 
-  static function h2(string $text): void {
-    CLI::printColored($text, "Black", "Grey", true);
+  static function h2(mixed $text): void {
+    CLI::printColored(print_r($text, true), "Black", "Grey", true);
   }
 
-  static function h3(string $text): void {
-    CLI::printColored($text, "Brown", "Grey", true);
+  static function h3(mixed $text): void {
+    CLI::printColored(print_r($text, true), "Brown", "Grey", true);
   }
 
-  static function h(string $text): void {
-    CLI::printColored($text, "Grey", "Black", true);
+  static function h(mixed $text): void {
+    CLI::printColored(print_r($text, true), "Grey", "Black", true);
   }
 
-  static function warning(string $text): void {
-    CLI::printColored($text, "Brown");
+  static function warning(mixed $text): void {
+    CLI::printColored(print_r($text, true), "Brown");
   }
 
-  static function error(string $text): void {
-    CLI::printColored($text, "Red", null, true);
+  static function error(mixed $text): void {
+    CLI::printColored(print_r($text, true), "Red", null, true);
   }
 
-  static function success(string $text): void {
-    CLI::printColored($text, "Green");
+  static function success(mixed $text): void {
+    CLI::printColored(print_r($text, true), "Green");
   }
 
-  static private function printColored(string $text, string $fg, string $bg = null, bool $bold = false): void {
+  static private function printColored(mixed $text, string $fg, string $bg = null, bool $bold = false): void {
     $colorString = ($bold ? '1' : '0') . ';' . CLI::foreground[$fg] . ($bg ? ';' . CLI::background[$bg] : '');
     echo "\n\e[{$colorString}m$text\e[0m";
   }

--- a/backend/src/helper/Folder.class.php
+++ b/backend/src/helper/Folder.class.php
@@ -3,7 +3,9 @@
 declare(strict_types=1);
 
 class Folder {
-  // stream save (PHP's function glob is not)
+  /** returns filepath
+   * stream save (PHP's function glob is not)
+   * **/
   static function glob(string $dir, string $filePattern = null, $reverse = false): array {
     if (!file_exists($dir) or !is_dir($dir)) {
       return [];

--- a/backend/src/workspace/UploadedFilesHandler.class.php
+++ b/backend/src/workspace/UploadedFilesHandler.class.php
@@ -58,7 +58,7 @@ class UploadedFilesHandler {
       $uploadedFiles = [$uploadedFiles];
     }
 
-    $importedFiles = [];
+    $filesToImport = [];
 
     foreach ($uploadedFiles as $uploadedFile) {
       /** @var UploadedFile $uploadedFile */
@@ -74,9 +74,9 @@ class UploadedFilesHandler {
       }
       $originalFileName = $uploadedFile->getClientFilename();
       $uploadedFile->moveTo($workspacePath . '/' . $originalFileName);
-      $importedFiles[] = $originalFileName;
+      $filesToImport[] = $originalFileName;
     }
 
-    return $importedFiles;
+    return $filesToImport;
   }
 }

--- a/backend/src/workspace/Workspace.class.php
+++ b/backend/src/workspace/Workspace.class.php
@@ -216,7 +216,6 @@ class Workspace {
   }
 
   protected function validateUncategorizedFiles(array $localFilePaths): array {
-    require_once '/var/www/backend/src/data-collection/FileType.enum.php'; // todo how to integrate into autoloader
     $filesPerType = array_fill_keys(Workspace::subFolders, []);
 
     $localFiles = [];

--- a/backend/src/workspace/WorkspaceCache.class.php
+++ b/backend/src/workspace/WorkspaceCache.class.php
@@ -1,4 +1,5 @@
 <?php
+
 /** @noinspection PhpUnhandledExceptionInspection */
 declare(strict_types=1);
 
@@ -26,24 +27,24 @@ class WorkspaceCache {
       }
     }
   }
-  public function loadFilesPerTypeFromDb(FileType $fileType): void {
 
-    foreach (FileType::getDependantTypes($fileType) as $type) {
-      $pattern = ($type == 'Resource') ? "*.*" : "*.[xX][mM][lL]";
-      $filePaths = Folder::glob($this->workspace->getOrCreateSubFolderPath($type), $pattern, true);
+  public function validate(?string $onlyValidateThisType = null): void {
+    foreach ($this->cachedFiles as $type => $fileSet) {
+      if ($onlyValidateThisType) {
+        if ($type === $onlyValidateThisType) {
 
-      foreach ($filePaths as $filePath) {
-        $file = File::get($filePath, $type);
-        $this->addFile($type, $file);
-      }
-    }
-  }
+          foreach ($fileSet as $file) {
+            /* @var $file File */
+            $file->crossValidate($this);
+          }
+        }
 
-  public function validate(): void {
-    foreach ($this->cachedFiles as $fileSet) {
-      foreach ($fileSet as $file) {
-        /* @var $file File */
-        $file->crossValidate($this);
+      } else {
+        foreach ($fileSet as $file) {
+          /* @var $file File */
+          $file->crossValidate($this);
+        }
+
       }
     }
 

--- a/backend/src/workspace/WorkspaceCache.class.php
+++ b/backend/src/workspace/WorkspaceCache.class.php
@@ -26,13 +26,9 @@ class WorkspaceCache {
       }
     }
   }
-  public function loadAllFromDb(): void {
-    // wie weiß man an dieser Stelle welche Dateien die relevanten sind? nur diese per SQL holen
+  public function loadFilesPerTypeFromDb(FileType $fileType): void {
 
-    // danach diese Files direkt mit $this->addFile() in den Cache aufnehmen
-
-
-    foreach (Workspace::subFolders as $type) {
+    foreach (FileType::getDependantTypes($fileType) as $type) {
       $pattern = ($type == 'Resource') ? "*.*" : "*.[xX][mM][lL]";
       $filePaths = Folder::glob($this->workspace->getOrCreateSubFolderPath($type), $pattern, true);
 

--- a/backend/src/workspace/WorkspaceCache.class.php
+++ b/backend/src/workspace/WorkspaceCache.class.php
@@ -29,22 +29,17 @@ class WorkspaceCache {
   }
 
   public function validate(?string $onlyValidateThisType = null): void {
-    foreach ($this->cachedFiles as $type => $fileSet) {
-      if ($onlyValidateThisType) {
-        if ($type === $onlyValidateThisType) {
-
-          foreach ($fileSet as $file) {
-            /* @var $file File */
-            $file->crossValidate($this);
-          }
-        }
-
-      } else {
+    if ($onlyValidateThisType) {
+      foreach ($this->cachedFiles[$onlyValidateThisType] as $file) {
+        /* @var $file File */
+        $file->crossValidate($this);
+      }
+    } else {
+      foreach ($this->cachedFiles as $fileSet) {
         foreach ($fileSet as $file) {
           /* @var $file File */
           $file->crossValidate($this);
         }
-
       }
     }
 

--- a/backend/src/workspace/WorkspaceCache.class.php
+++ b/backend/src/workspace/WorkspaceCache.class.php
@@ -15,12 +15,28 @@ class WorkspaceCache {
     $this->initializeFilesArray();
   }
 
-  public function loadAllFiles(): void {
+  public function loadFiles(): void {
     foreach (Workspace::subFolders as $type) {
       $pattern = ($type == 'Resource') ? "*.*" : "*.[xX][mM][lL]";
-      $files = Folder::glob($this->workspace->getOrCreateSubFolderPath($type), $pattern, true);
+      $filePaths = Folder::glob($this->workspace->getOrCreateSubFolderPath($type), $pattern, true);
 
-      foreach ($files as $filePath) {
+      foreach ($filePaths as $filePath) {
+        $file = File::get($filePath, $type);
+        $this->addFile($type, $file);
+      }
+    }
+  }
+  public function loadAllFromDb(): void {
+    // wie weiß man an dieser Stelle welche Dateien die relevanten sind? nur diese per SQL holen
+
+    // danach diese Files direkt mit $this->addFile() in den Cache aufnehmen
+
+
+    foreach (Workspace::subFolders as $type) {
+      $pattern = ($type == 'Resource') ? "*.*" : "*.[xX][mM][lL]";
+      $filePaths = Folder::glob($this->workspace->getOrCreateSubFolderPath($type), $pattern, true);
+
+      foreach ($filePaths as $filePath) {
         $file = File::get($filePath, $type);
         $this->addFile($type, $file);
       }

--- a/backend/test/unit/controller/WorkspaceControllerTest.php
+++ b/backend/test/unit/controller/WorkspaceControllerTest.php
@@ -353,11 +353,23 @@ final class WorkspaceControllerTest extends TestCase {
   }
 
   function test_postFile() {
+    $booklet = XMLFileBooklet::fromString(file_get_contents(ROOT_DIR . '/sampledata/Booklet.xml'), 'Booklet.xml');
+    $unit = XMLFileUnit::fromString(file_get_contents(ROOT_DIR . '/sampledata/Unit2.xml') . 'is_bogus', 'Unit2.xml');
+    $testtakers = XMLFileTesttakers::fromString(file_get_contents(ROOT_DIR . '/sampledata/Testtakers.xml'), 'Testtakers.xml');
     $files = [
-      'Booklet.xml' => XMLFileBooklet::fromString(file_get_contents(ROOT_DIR . '/sampledata/Booklet.xml'), 'Booklet.xml'),
-      'Unit2.xml' => XMLFileUnit::fromString(file_get_contents(ROOT_DIR . '/sampledata/Unit2.xml') . 'is_bogus', 'Unit2.xml'),
-      'Testtakers.xml' => XMLFileTesttakers::fromString(file_get_contents(ROOT_DIR . '/sampledata/Testtakers.xml'), 'Testtakers.xml')
+      'Booklet.xml' => $booklet,
+      'Unit2.xml' => $unit,
+      'Testtakers.xml' => $testtakers
     ];
+
+    $fileReports = array_reduce(
+      array_keys($files),
+      function($agg, $fileName) use ($files) {
+        $agg[$fileName] = ['type' => $files[$fileName]->getType(), ...$files[$fileName]->getValidationReport()];
+        return $agg;
+      },
+      []
+    );
 
     $filesContents = array_reduce(
       array_keys($files),
@@ -371,7 +383,7 @@ final class WorkspaceControllerTest extends TestCase {
     $this->workspaceMock
       ->expects('importUncategorizedFiles')
       ->times(1)
-      ->andReturn($files);
+      ->andReturn($fileReports);
 
     $this->workspaceMock
       ->expects('setWorkspaceHash')

--- a/backend/test/unit/controller/WorkspaceControllerTest.php
+++ b/backend/test/unit/controller/WorkspaceControllerTest.php
@@ -369,7 +369,7 @@ final class WorkspaceControllerTest extends TestCase {
     );
 
     $this->workspaceMock
-      ->expects('importUnsortedFiles')
+      ->expects('importUncategorizedFiles')
       ->times(1)
       ->andReturn($files);
 

--- a/backend/test/unit/mock-classes/ZIPMock.php
+++ b/backend/test/unit/mock-classes/ZIPMock.php
@@ -14,15 +14,13 @@ class ZIP {
     self::extractFile(self::$mockArchive, $extractionPath);
   }
 
-  static private function extractFile($mockArchiveFolder, $extractionPath) {
+  static private function extractFile(array $mockArchiveFolder, string $extractionPath) {
     foreach ($mockArchiveFolder as $name => $content) {
       if (is_array($content)) {
         mkdir("$extractionPath/$name");
         self::extractFile($content, "$extractionPath/$name");
-
       } else {
         file_put_contents("$extractionPath/$name", $content);
-
       }
     }
   }

--- a/backend/test/unit/workspace/WorkspaceCacheTest.php
+++ b/backend/test/unit/workspace/WorkspaceCacheTest.php
@@ -30,7 +30,7 @@ class WorkspaceCacheTest extends TestCase {
     ]);
     VfsForTest::setUp(true);
     $this->workspaceCache = new WorkspaceCache(new Workspace(1));
-    $this->workspaceCache->loadAllFiles();
+    $this->workspaceCache->loadFiles();
   }
 
   function test_validate() {

--- a/backend/test/unit/workspace/WorkspaceTest.php
+++ b/backend/test/unit/workspace/WorkspaceTest.php
@@ -249,7 +249,7 @@ class WorkspaceTest extends TestCase {
     $workspace = new Workspace(1);
     $result = $workspace->importUncategorizedFiles(['valid.xml', 'P.HTML']);
 
-    $this->assertArrayNotHasKey('error', $result["valid.xml"]->getValidationReport(), 'valid file has no errors');
+    $this->assertArrayNotHasKey('error', $result["valid.xml"], 'valid file has no errors');
     $this->assertTrue(file_exists(DATA_DIR . '/ws_1/Unit/valid.xml'), 'valid file is imported');
     $this->assertFalse(file_exists(DATA_DIR . '/ws_1/valid.xml'), 'cleanup after import');
   }
@@ -269,7 +269,7 @@ class WorkspaceTest extends TestCase {
 
     $this->assertGreaterThan(
       0,
-      count($result["invalid.xml"]->getValidationReport()['error']),
+      count($result["invalid.xml"]['error']),
       'invalid file has error report'
     );
     $this->assertFalse(file_exists(DATA_DIR . '/ws_1/Unit/invalid.xml'), 'invalid file is rejected');
@@ -310,7 +310,7 @@ class WorkspaceTest extends TestCase {
     );
     $this->assertGreaterThan(
       0,
-      count($result["valid3.xml"]->getValidationReport()['error']),
+      count($result["valid3.xml"]['error']),
       'return warning on duplicate id if file names are not the same'
     );
     $this->assertFalse(file_exists(DATA_DIR . '/ws_1/valid3.xml'), 'cleanup after import');
@@ -353,7 +353,7 @@ class WorkspaceTest extends TestCase {
     );
     $this->assertGreaterThan(
       0,
-      count($result["valid.xml"]->getValidationReport()['warning']),
+      count($result["valid.xml"]['warning']),
       'return warning if filename and id is the same'
     );
     $this->assertFalse(file_exists(DATA_DIR . '/ws_1/valid.xml'), 'cleanup after import');
@@ -814,15 +814,15 @@ class WorkspaceTest extends TestCase {
     file_put_contents(DATA_DIR . '/ws_1/testtakers.xml', self::dangerousTesttakers);
 
     $result = $workspace->importUncategorizedFiles(['testtakers.xml']);
-    $this->assertArrayNotHasKey('error', $result["testtakers.xml"]->getValidationReport(), 'valid file has no errors');
+    $this->assertArrayNotHasKey('error', $result["testtakers.xml"], 'valid file has no errors');
     $this->assertTrue(file_exists(DATA_DIR . '/ws_1/Testtakers/testtakers.xml'), 'valid file is imported');
     $this->assertFalse(file_exists(DATA_DIR . '/ws_1/testtakers.xml'), 'cleanup after import');
   }
 
   private function getErrorsFromValidationResult($result): array {
     return array_filter(
-      array_map(function ($file) {
-        return $file->getValidationReport()['error'] ?? null;
+      array_map(function (array $fileReport) {
+        return $fileReport['error'] ?? null;
       }, $result),
       'is_array'
     );

--- a/backend/test/unit/workspace/WorkspaceTest.php
+++ b/backend/test/unit/workspace/WorkspaceTest.php
@@ -226,7 +226,7 @@ class WorkspaceTest extends TestCase {
     $this->assertEquals($expectation, $result);
   }
 
-  function test_importUnsortedFiles_singleFile() {
+  function test_importUncategorizedFiles_singleFile() {
     $this->workspaceDaoMock
       ->expects('storeFile')
       ->twice();
@@ -235,26 +235,26 @@ class WorkspaceTest extends TestCase {
       ->andReturn([[], []])
       ->twice();
     $this->workspaceDaoMock
-      ->expects('getRelatingFiles')
+      ->expects('getDependentFiles')
       ->andReturn([]) // TODO add realistic return!
       ->times(2);
     $workspace = new Workspace(1);
 
     file_put_contents(DATA_DIR . '/ws_1/valid.xml', self::validFile);
     file_put_contents(DATA_DIR . '/ws_1/Resource/P.HTML', "this would be a player");
-    $result = $workspace->importUnsortedFiles(['valid.xml']);
+    $result = $workspace->importUncategorizedFiles(['valid.xml']);
     $this->assertArrayNotHasKey('error', $result["valid.xml"]->getValidationReport(), 'valid file has no errors');
     $this->assertTrue(file_exists(DATA_DIR . '/ws_1/Unit/valid.xml'), 'valid file is imported');
     $this->assertFalse(file_exists(DATA_DIR . '/ws_1/valid.xml'), 'cleanup after import');
 
     file_put_contents(DATA_DIR . '/ws_1/invalid.xml', self::invalidFile);
-    $result = $workspace->importUnsortedFiles(['invalid.xml']);
+    $result = $workspace->importUncategorizedFiles(['invalid.xml']);
     $this->assertGreaterThan(0, count($result["invalid.xml"]->getValidationReport()['error']), 'invalid file has error report');
     $this->assertFalse(file_exists(DATA_DIR . '/ws_1/Unit/invalid.xml'), 'invalid file is rejected');
     $this->assertFalse(file_exists(DATA_DIR . '/ws_1/invalid.xml'), 'cleanup after import');
 
     file_put_contents(DATA_DIR . '/ws_1/valid3.xml', self::validFile2);
-    $result = $workspace->importUnsortedFiles(['valid3.xml']);
+    $result = $workspace->importUncategorizedFiles(['valid3.xml']);
     $this->assertFalse(file_exists(DATA_DIR . '/ws_1/Unit/valid3.xml'), 'reject on duplicate id if file names are not the same');
     $this->assertStringContainsString(
       '1st valid file',
@@ -265,7 +265,7 @@ class WorkspaceTest extends TestCase {
     $this->assertFalse(file_exists(DATA_DIR . '/ws_1/valid3.xml'), 'cleanup after import');
 
     file_put_contents(DATA_DIR . '/ws_1/valid.xml', self::validFile2);
-    $result = $workspace->importUnsortedFiles(['valid.xml']);
+    $result = $workspace->importUncategorizedFiles(['valid.xml']);
     $this->assertStringContainsString(
       '2nd valid file',
       file_get_contents(DATA_DIR . '/ws_1/Unit/valid.xml'),
@@ -275,7 +275,7 @@ class WorkspaceTest extends TestCase {
     $this->assertFalse(file_exists(DATA_DIR . '/ws_1/valid.xml'), 'cleanup after import');
   }
 
-  function test_importUnsortedFiles_multipleFilesWithDependencies() {
+  function test_importUncategorizedFiles_multipleFilesWithDependencies() {
     $this->workspaceDaoMock
       ->expects('storeFile')
       ->times(4);
@@ -294,7 +294,7 @@ class WorkspaceTest extends TestCase {
       ->expects('updateLoginSource')
       ->once();
     $this->workspaceDaoMock
-      ->expects('getRelatingFiles')
+      ->expects('getDependentFiles')
       ->andReturn([]) // TODO add realistic return!
       ->times(4);
     $workspace = new Workspace(1);
@@ -306,7 +306,7 @@ class WorkspaceTest extends TestCase {
       'valid_unit.xml' => self::validUnit
     ];
 
-    $result = $workspace->importUnsortedFiles(["archive.zip"]);
+    $result = $workspace->importUncategorizedFiles(["archive.zip"]);
     $errors = $this->getErrorsFromValidationResult($result);
 
     $this->assertCount(0, $errors);
@@ -322,7 +322,7 @@ class WorkspaceTest extends TestCase {
     $this->assertTrue(file_exists(DATA_DIR . '/ws_1/Testtakers/valid_testtakers.xml'), 'import testtakers');
   }
 
-  function test_importUnsortedFiles_multipleFilesWithMissingDependencies() {
+  function test_importUncategorizedFiles_multipleFilesWithMissingDependencies() {
     $this->workspaceDaoMock
       ->expects('storeFile')
       ->never();
@@ -339,7 +339,7 @@ class WorkspaceTest extends TestCase {
       ->expects('updateLoginSource')
       ->never();
     $this->workspaceDaoMock
-      ->expects('getRelatingFiles')
+      ->expects('getDependentFiles')
       ->never();
     $workspace = new Workspace(1);
 
@@ -349,7 +349,7 @@ class WorkspaceTest extends TestCase {
       'valid_unit.xml' => self::validUnit
     ];
 
-    $result = $workspace->importUnsortedFiles(["archive.zip"]);
+    $result = $workspace->importUncategorizedFiles(["archive.zip"]);
     $errors = $this->getErrorsFromValidationResult($result);
 
     $this->assertCount(3, $errors);
@@ -363,7 +363,7 @@ class WorkspaceTest extends TestCase {
     $this->assertFalse(file_exists(DATA_DIR . '/ws_1/Testtakers/valid_testtakers.xml'), 'import testtakers');
   }
 
-  function test_importUnsortedFiles_zipWithValidFilesWithDependencies() {
+  function test_importUncategorizedFiles_zipWithValidFilesWithDependencies() {
     $this->workspaceDaoMock
       ->expects('storeFile')
       ->times(4);
@@ -382,7 +382,7 @@ class WorkspaceTest extends TestCase {
       ->expects('updateLoginSource')
       ->once();
     $this->workspaceDaoMock
-      ->expects('getRelatingFiles')
+      ->expects('getDependentFiles')
       ->andReturn([]) // TODO add realistic return!
       ->times(4);
     $workspace = new Workspace(1);
@@ -394,7 +394,7 @@ class WorkspaceTest extends TestCase {
       'valid_unit.xml' => self::validUnit
     ];
 
-    $result = $workspace->importUnsortedFiles(["archive.zip"]);
+    $result = $workspace->importUncategorizedFiles(["archive.zip"]);
     $errors = $this->getErrorsFromValidationResult($result);
 
     $this->assertCount(0, $errors);
@@ -408,7 +408,7 @@ class WorkspaceTest extends TestCase {
     $this->assertTrue(file_exists(DATA_DIR . '/ws_1/Testtakers/valid_testtakers.xml'), 'import testtakers from ZIP');
   }
 
-  function test_importUnsortedFiles_zip_rejectInvalidUnitAndDependantFiles() {
+  function test_importUncategorizedFiles_zip_rejectInvalidUnitAndDependantFiles() {
     $this->workspaceDaoMock
       ->shouldReceive('storeFile')
       ->once();
@@ -416,7 +416,7 @@ class WorkspaceTest extends TestCase {
       ->shouldReceive('storeRelations')
       ->never();
     $this->workspaceDaoMock
-      ->shouldReceive('getRelatingFiles')
+      ->shouldReceive('getDependentFiles')
       ->andReturn([])
       ->once();
     $workspace = new Workspace(1);
@@ -428,7 +428,7 @@ class WorkspaceTest extends TestCase {
       'invalid_unit.xml' => 'INVALID'
     ];
 
-    $result = $workspace->importUnsortedFiles(["archive.zip"]);
+    $result = $workspace->importUncategorizedFiles(["archive.zip"]);
     $errors = $this->getErrorsFromValidationResult($result);
 
     $this->assertCount(3, $errors);
@@ -453,7 +453,7 @@ class WorkspaceTest extends TestCase {
     );
   }
 
-  function test_importUnsortedFiles_zip_rejectInvalidBookletAndDependantFiles() {
+  function test_importUncategorizedFiles_zip_rejectInvalidBookletAndDependantFiles() {
     $this->workspaceDaoMock
       ->shouldReceive('storeFile')
       ->twice();
@@ -462,7 +462,7 @@ class WorkspaceTest extends TestCase {
       ->andReturn([[], []])
       ->once();
     $this->workspaceDaoMock
-      ->expects('getRelatingFiles')
+      ->expects('getDependentFiles')
       ->andReturn([]) // TODO add realistic return!
       ->times(2);
     $workspace = new Workspace(1);
@@ -474,7 +474,7 @@ class WorkspaceTest extends TestCase {
       'valid_unit.xml' => self::validUnit
     ];
 
-    $result = $workspace->importUnsortedFiles(["archive.zip"]);
+    $result = $workspace->importUncategorizedFiles(["archive.zip"]);
     $errors = $this->getErrorsFromValidationResult($result);
 
     $this->assertCount(2, $errors);
@@ -498,7 +498,7 @@ class WorkspaceTest extends TestCase {
     );
   }
 
-  function test_importUnsortedFiles_zip_rejectOnDuplicateId() {
+  function test_importUncategorizedFiles_zip_rejectOnDuplicateId() {
     $this->workspaceDaoMock
       ->shouldReceive('storeFile')
       ->never();
@@ -511,7 +511,7 @@ class WorkspaceTest extends TestCase {
       'file_with_used_id.xml' => '<Unit ><Metadata><Id>UNIT.SAMPLE</Id><Label>l</Label></Metadata><Definition player="p">d</Definition></Unit>',
     ];
 
-    $result = $workspace->importUnsortedFiles(["archive.zip"]);
+    $result = $workspace->importUncategorizedFiles(["archive.zip"]);
     $errors = $this->getErrorsFromValidationResult($result);
 
     $this->assertCount(1, $errors);
@@ -523,7 +523,7 @@ class WorkspaceTest extends TestCase {
     );
   }
 
-  function test_importUnsortedFiles_zip_handleSubFolders() {
+  function test_importUncategorizedFiles_zip_handleSubFolders() {
     $this->workspaceDaoMock
       ->shouldReceive('storeFile')
       ->times(4);
@@ -544,7 +544,7 @@ class WorkspaceTest extends TestCase {
       ->expects('updateLoginSource')
       ->once();
     $this->workspaceDaoMock
-      ->expects('getRelatingFiles')
+      ->expects('getDependentFiles')
       ->andReturn([]) // TODO add realistic return!
       ->times(4);
     $workspace = new Workspace(1);
@@ -563,7 +563,7 @@ class WorkspaceTest extends TestCase {
       ]
     ];
 
-    $result = $workspace->importUnsortedFiles(["archive.zip"]);
+    $result = $workspace->importUncategorizedFiles(["archive.zip"]);
     $errors = $this->getErrorsFromValidationResult($result);
     $this->assertCount(1, $errors);
 
@@ -591,7 +591,7 @@ class WorkspaceTest extends TestCase {
   }
 
   // regression test for #235
-  function test_importUnsortedFiles_multiMonitor() {
+  function test_importUncategorizedFiles_multiMonitor() {
     $this->workspaceDaoMock
       ->expects('storeFile')
       ->once();
@@ -600,7 +600,7 @@ class WorkspaceTest extends TestCase {
       ->andReturn([[], []])
       ->once();
     $this->workspaceDaoMock
-      ->expects('getRelatingFiles')
+      ->expects('getDependentFiles')
       ->andReturn([]) // TODO add realistic return!
       ->once();
     $this->workspaceDaoMock
@@ -610,7 +610,7 @@ class WorkspaceTest extends TestCase {
     $workspace = new Workspace(1);
     file_put_contents(DATA_DIR . '/ws_1/testtakers.xml', self::dangerousTesttakers);
 
-    $result = $workspace->importUnsortedFiles(['testtakers.xml']);
+    $result = $workspace->importUncategorizedFiles(['testtakers.xml']);
     $this->assertArrayNotHasKey('error', $result["testtakers.xml"]->getValidationReport(), 'valid file has no errors');
     $this->assertTrue(file_exists(DATA_DIR . '/ws_1/Testtakers/testtakers.xml'), 'valid file is imported');
     $this->assertFalse(file_exists(DATA_DIR . '/ws_1/testtakers.xml'), 'cleanup after import');

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,7 @@ layout: default
 * Im Workspace-Admin werden bei Klick auf eine Datei nun auch alle abhängigen Dateien gekennzeichnet. Damit lässt sich 
   feststellen, welche Dateien vorher bzw. zeitgleich gelöscht werden müssen, um eine Datei erfolgreich zu löschen - bevor
   der 'Löschen' Button geklickt werden muss.
+* Die Dateien werden zuerst angezeigt, können dann bei weiterem Laden erst einen Moment später gelöscht werden. 
 
 ### Bugfix
 * Wenn es zum Timeout kam, wurde die Sperrung des Workspaces während des uploads wurde nicht mehr korrekt aufgehoben.   

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,12 @@ layout: default
 ---
 
 ## [next]
+
+### neue Features
+* Im Workspace-Admin werden bei Klick auf eine Datei nun auch alle abhängigen Dateien gekennzeichnet. Damit lässt sich 
+  feststellen, welche Dateien vorher bzw. zeitgleich gelöscht werden müssen, um eine Datei erfolgreich zu löschen - bevor
+  der 'Löschen' Button geklickt werden muss.
+
 ### Bugfix
 * Wenn es zum Timeout kam, wurde die Sperrung des Workspaces während des uploads wurde nicht mehr korrekt aufgehoben.   
 
@@ -13,13 +19,21 @@ layout: default
   von Testdaten.
 * Während Initialization Tests werden fake patches angelegt. Diese werden nun nach erfolgreichen Abschluss der Tests 
   wieder gelöscht. Damit können Initialization Tests mehrmals hintereinander gestartet werden.
+* Die Berechnung der Dateigröße von Dateien innerhalb des Workspace-Admin wurde optimiert. Die Berechnung der Dateigröße 
+  erfolgt nun im Frontend. Dies führt zu einer schnelleren Anzeige des Dashboards und einer Entlastung des Backends.
+* Die Uploadgeschwindigkeit für einzelne Dateien im Workspace-Admin wurde erheblich verbessert.
 
 ### Deployment
 * dpgk, welches aus nicht-Debian Versionen fehlt, wird für den updater nicht mehr benötigt.
 * Es wurden weitere Umgebungsvariablen eingeführt. Diese lauten "OVERWRITE_INSTALLATION", "SKIP_READ_FILES", "SKIP_DB_INTEGRITY" und "NO_SAMPLE_DATA". 
   Der default Wert all dieser Variablen ist "no". Wenn einer der Variablen auf "yes" gesetzt wird so werden zusätzliche Parameter beim Initialisieren 
   des Backends mitgegeben. Diese Umgebungsvariablen können nur manuell gesetzt werden und die einzelnen Parameter sind im .env File genauer beschrieben.
+* Das benötigte PHP memory_limit für den Datei-Upload im Workspace-Admin wurde verringert, da dieser nun effizienter arbeitet.
 
+### Development
+* make Befehle für Unit Tests können nun mit einem 'target' Argument aufgerufen werden, um gezielt nur bestimmte Tests auszuführen.
+* make backend-refresh-autoload baut nun den BE Container neu auf, um sicherzustellen, dass alle Klassen geladen werden können.
+* mixed type könenn als Argumente in CLI print-functions gegeben werden.
 
 ## 15.1.8
 ### Bugfix

--- a/docs/api/workspace.spec.yml
+++ b/docs/api/workspace.spec.yml
@@ -339,30 +339,30 @@ paths:
                     type: Booklet
                     id: BOOKLET.SAMPLE-1
                     report: []
+                    dependencies: [{"object_name": "SAMPLE_UNIT.XML","relationship_type": "containsUnit"},{"object_name": "SAMPLE_UNIT2.XML", "relationship_type": "containsUnit"},{"object_name": "verona-player-simple-6.0.html","relationship_type": "usesPlayer"},{"object_name": "SAMPLE_UNITCONTENTS.HTM","relationship_type": "isDefinedBy"},{"object_name": "sample_resource_package.itcr.zip","relationship_type": "usesPlayerResource"}]
                     info:
                       label: Sample booklet
                       description: This a sample booklet for testing/development/showcase purposes.
-                      totalSize: 69013
                   - name: SAMPLE_BOOKLET2.XML
                     size: 557
                     modificationTime: 1673525827
                     type: Booklet
                     id: BOOKLET.SAMPLE-2
                     report: []
+                    dependencies: [{"object_name":"SAMPLE_UNIT.XML","relationship_type":"containsUnit"},{"object_name":"SAMPLE_UNIT2.XML","relationship_type":"containsUnit"},{"object_name":"verona-player-simple-6.0.html","relationship_type":"usesPlayer"},{"object_name":"SAMPLE_UNITCONTENTS.HTM","relationship_type":"isDefinedBy"},{"object_name":"sample_resource_package.itcr.zip","relationship_type":"usesPlayerResource"}]
                     info:
                       label: Reduced Booklet
                       description: ''
-                      totalSize: 52700
                   - name: SAMPLE_BOOKLET3.XML
                     size: 1277
                     modificationTime: 1673525827
                     type: Booklet
                     id: BOOKLET.SAMPLE-3
                     report: []
+                    dependencies: [{"object_name":"SAMPLE_UNIT.XML","relationship_type":"containsUnit"},{"object_name":"SAMPLE_UNIT2.XML","relationship_type":"containsUnit"},{"object_name":"verona-player-simple-6.0.html","relationship_type":"usesPlayer"},{"object_name":"SAMPLE_UNITCONTENTS.HTM","relationship_type":"isDefinedBy"},{"object_name":"sample_resource_package.itcr.zip","relationship_type":"usesPlayerResource"}]
                     info:
                       label: Similar Booklet to Sample 1
                       description: some description
-                      totalSize: 68893
                 SysCheck:
                   - name: SAMPLE_SYSCHECK.XML
                     size: 1232
@@ -370,6 +370,7 @@ paths:
                     type: SysCheck
                     id: SYSCHECK.SAMPLE
                     report: []
+                    dependencies: [{"object_name":"SAMPLE_UNIT.XML","relationship_type":"containsUnit"},{"object_name":"verona-player-simple-6.0.html","relationship_type":"usesPlayer"},{"object_name":"SAMPLE_UNITCONTENTS.HTM","relationship_type":"isDefinedBy"}]
                     info:
                       label: An example SysCheck definition
                       description: An example SysCheck definition with long description
@@ -380,6 +381,7 @@ paths:
                     type: Testtakers
                     id: SAMPLE_TESTTAKERS.XML
                     report: []
+                    dependencies: [{"object_name":"SAMPLE_BOOKLET.XML","relationship_type":"hasBooklet"},{"object_name":"SAMPLE_BOOKLET2.XML","relationship_type":"hasBooklet"},{"object_name":"SAMPLE_BOOKLET3.XML","relationship_type":"hasBooklet"},{"object_name":"SAMPLE_UNIT.XML","relationship_type":"containsUnit"},{"object_name":"SAMPLE_UNIT2.XML","relationship_type":"containsUnit"},{"object_name":"verona-player-simple-6.0.html","relationship_type":"usesPlayer"},{"object_name":"SAMPLE_UNITCONTENTS.HTM","relationship_type":"isDefinedBy"},{"object_name":"sample_resource_package.itcr.zip","relationship_type":"usesPlayerResource"}]
                     info:
                       label: ''
                       description: This file contains some logins for testing and works a a sample for developers.
@@ -393,10 +395,10 @@ paths:
                     report:
                       info:
                         - "`1` attachment(s) requested."
+                    dependencies: [{"object_name":"verona-player-simple-6.0.html","relationship_type":"usesPlayer"},{"object_name":"SAMPLE_UNITCONTENTS.HTM","relationship_type":"isDefinedBy"}]
                     info:
                       label: A sample unit
                       description: This is a sample unit showing the possibilities of the sample player.
-                      totalSize: 15473
                   - name: SAMPLE_UNIT2.XML
                     size: 1394
                     modificationTime: 1673525827
@@ -405,10 +407,10 @@ paths:
                     report:
                       warning:
                         - Element `/Unit/Definition/@type` is deprecated.
+                    dependencies: [{"object_name":"verona-player-simple-6.0.html","relationship_type":"usesPlayer"},{"object_name":"sample_resource_package.itcr.zip","relationship_type":"usesPlayerResource"}]
                     info:
                       label: A sample unit
                       description: This is an Unit
-                      totalSize: 1806
                 Resource:
                   - name: SAMPLE_UNITCONTENTS.HTM
                     size: 14195
@@ -416,6 +418,7 @@ paths:
                     type: Resource
                     id: SAMPLE_UNITCONTENTS.HTM
                     report: []
+                    dependencies: []
                     info:
                       label: ''
                       description: ''
@@ -427,6 +430,7 @@ paths:
                     report:
                       info:
                         - Contains 0 files.
+                    dependencies: []
                     info:
                       label: ''
                       description: ''
@@ -438,6 +442,7 @@ paths:
                     report:
                       info:
                         - 'Verona-Version: 4.0'
+                    dependencies: []
                     info:
                       label: Simple HTML Player
                       description: This is a simple, dependency-less, vanilla-js-written, but full-featured

--- a/docs/api/workspace.spec.yml
+++ b/docs/api/workspace.spec.yml
@@ -339,6 +339,249 @@ paths:
                     type: Booklet
                     id: BOOKLET.SAMPLE-1
                     report: []
+                    dependencies: []
+                    info:
+                      label: Sample booklet
+                      description: This a sample booklet for testing/development/showcase purposes.
+                  - name: SAMPLE_BOOKLET2.XML
+                    size: 557
+                    modificationTime: 1673525827
+                    type: Booklet
+                    id: BOOKLET.SAMPLE-2
+                    report: []
+                    dependencies: []
+                    info:
+                      label: Reduced Booklet
+                      description: ''
+                  - name: SAMPLE_BOOKLET3.XML
+                    size: 1277
+                    modificationTime: 1673525827
+                    type: Booklet
+                    id: BOOKLET.SAMPLE-3
+                    report: []
+                    dependencies: []
+                    info:
+                      label: Similar Booklet to Sample 1
+                      description: some description
+                SysCheck:
+                  - name: SAMPLE_SYSCHECK.XML
+                    size: 1232
+                    modificationTime: 1673525827
+                    type: SysCheck
+                    id: SYSCHECK.SAMPLE
+                    report: []
+                    info:
+                      label: An example SysCheck definition
+                      description: An example SysCheck definition with long description
+                Testtakers:
+                  - name: SAMPLE_TESTTAKERS.XML
+                    size: 2173
+                    modificationTime: 1673525827
+                    type: Testtakers
+                    id: SAMPLE_TESTTAKERS.XML
+                    report: []
+                    dependencies: []
+                    info:
+                      label: ''
+                      description: This file contains some logins for testing and works a a sample for developers.
+                      testtakers: 10
+                Unit:
+                  - name: SAMPLE_UNIT.XML
+                    size: 1278
+                    modificationTime: 1673525827
+                    type: Unit
+                    id: UNIT.SAMPLE
+                    report:
+                      info:
+                        - "`1` attachment(s) requested."
+                    dependencies: []
+                    info:
+                      label: A sample unit
+                      description: This is a sample unit showing the possibilities of the sample player.
+                  - name: SAMPLE_UNIT2.XML
+                    size: 1394
+                    modificationTime: 1673525827
+                    type: Unit
+                    id: UNIT.SAMPLE-2
+                    report:
+                      warning:
+                        - Element `/Unit/Definition/@type` is deprecated.
+                    dependencies: []
+                    info:
+                      label: A sample unit
+                      description: This is an Unit
+                Resource:
+                  - name: SAMPLE_UNITCONTENTS.HTM
+                    size: 14195
+                    modificationTime: 1673525827
+                    type: Resource
+                    id: SAMPLE_UNITCONTENTS.HTM
+                    report: []
+                    dependencies: []
+                    info:
+                      label: ''
+                      description: ''
+                  - name: sample_resource_package.itcr.zip
+                    size: 412
+                    modificationTime: 1673525827
+                    type: Resource
+                    id: SAMPLE_RESOURCE_PACKAGE.ITCR.ZIP
+                    report:
+                      info:
+                        - Contains 0 files.
+                    dependencies: []
+                    info:
+                      label: ''
+                      description: ''
+                  - name: verona-player-simple-4.0.0.html
+                    size: 34864
+                    modificationTime: 1673525827
+                    type: Resource
+                    id: VERONA-PLAYER-SIMPLE-4.0.0.HTML
+                    report:
+                      info:
+                        - 'Verona-Version: 4.0'
+                    dependencies: []
+                    info:
+                      label: Simple HTML Player
+                      description: This is a simple, dependency-less, vanilla-js-written, but full-featured
+                        unit player, mainly as showcase for developers and for software-testing. It
+                        does implement the Verona 4.0.0-Standard and can be used for units containing
+                        simple any content in HTML-format. Unit Description ist the <code>form-content
+                        as HTML. Just give some names to the form element, and the player does the rest.
+                        Use some special Ids for some special buttons.
+                      veronaModuleType: player
+                      veronaVersion: '4.0'
+                      version: 4.0.0
+        "401":
+          description: Not authenticated
+        "403":
+          description: Forbidden
+        "404":
+          description: Workspace not found
+        "410":
+          description: Session Expired
+        "500":
+          description: Server Error
+    delete:
+      summary: delete files
+      description: deletes files from a workspace
+      tags:
+        - admin workspace
+      parameters:
+        - in: header
+          name: AuthToken
+          description: auth-token for admin-user with role "RW" (read/write) for this workspace
+          example: "a:user000000000.rw00000000"
+          required: true
+        - in: path
+          name: ws_id
+          description: workspace-id
+          example: 1
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                f:
+                  type: array
+                  description: array of file names
+                  items:
+                    type: string
+            example:
+              f:
+                - "SysCheck/SAMPLE_SYSCHECK.XML"
+                - "Unit/SAMPLE_UNIT.XML"
+                - "some rubbish"
+                - "a/b"
+                - "../../README.md"
+      responses:
+        "207":
+          description: OK, a list of files
+          content:
+            application/json:
+              example:
+                deleted:
+                  - "SysCheck/SAMPLE_SYSCHECK.XML"
+                did_not_exist:
+                  - "some rubbish"
+                  - "a/b"
+                not_allowed:
+                  - "../../README.md"
+                was_used:
+                  - "Unit/SAMPLE_UNIT.XML"
+        "401":
+          description: Not authenticated
+        "403":
+          description: Forbidden
+        "404":
+          description: Workspace not found
+        "409":
+          description: Workspace blocked by another upload or deletion action.
+        "410":
+          description: Session Expired
+        "500":
+          description: Server Error
+
+  /workspace/{ws_id}/files-dependencies:
+    post:
+      summary: get files with respective dependencies of workspace
+      description: get a list of all files with their in workspace
+      tags:
+        - admin workspace
+      parameters:
+        - in: header
+          name: AuthToken
+          description: auth-token for admin-user with role at least "RO" (read only) for this workspace
+          example: "a:user000000000.superadmin0"
+          required: true
+        - in: path
+          name: ws_id
+          description: workspace-id
+          example: 1
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                body:
+                  type: array
+                  description: array of file names
+                  items:
+                    type: string
+            example:
+              body:
+                - "SAMPLE_TESTTAKERS.XML"
+                - "SAMPLE_BOOKLET.XML"
+                - "SAMPLE_BOOKLET2.XML"
+                - "SAMPLE_BOOKLET3.XML"
+                - "SAMPLE_SYSCHECK.XML"
+                - "SAMPLE_UNIT.XML"
+                - "SAMPLE_UNIT2.XML"
+                - "sample_resource_package.itcr.zip"
+                - "SAMPLE_UNITCONTENTS.HTM"
+                - "verona-player-simple-6.0.html"
+      responses:
+        "200":
+          description: OK, a list of files
+          content:
+            application/json:
+              schema:
+                $ref: './components.spec.yml#/components/schemas/file_list'
+              example: # TODO add schema
+                Booklet:
+                  - name: SAMPLE_BOOKLET.XML
+                    size: 1397
+                    modificationTime: 1673525827
+                    type: Booklet
+                    id: BOOKLET.SAMPLE-1
+                    report: []
                     dependencies: [{"object_name": "SAMPLE_UNIT.XML","relationship_type": "containsUnit"},{"object_name": "SAMPLE_UNIT2.XML", "relationship_type": "containsUnit"},{"object_name": "verona-player-simple-6.0.html","relationship_type": "usesPlayer"},{"object_name": "SAMPLE_UNITCONTENTS.HTM","relationship_type": "isDefinedBy"},{"object_name": "sample_resource_package.itcr.zip","relationship_type": "usesPlayerResource"}]
                     info:
                       label: Sample booklet
@@ -460,68 +703,6 @@ paths:
           description: Forbidden
         "404":
           description: Workspace not found
-        "410":
-          description: Session Expired
-        "500":
-          description: Server Error
-    delete:
-      summary: delete files
-      description: deletes files from a workspace
-      tags:
-        - admin workspace
-      parameters:
-        - in: header
-          name: AuthToken
-          description: auth-token for admin-user with role "RW" (read/write) for this workspace
-          example: "a:user000000000.rw00000000"
-          required: true
-        - in: path
-          name: ws_id
-          description: workspace-id
-          example: 1
-          required: true
-          schema:
-            type: integer
-      requestBody:
-        content:
-          application/json:
-            schema:
-              properties:
-                f:
-                  type: array
-                  description: array of file names
-                  items:
-                    type: string
-            example:
-              f:
-                - "SysCheck/SAMPLE_SYSCHECK.XML"
-                - "Unit/SAMPLE_UNIT.XML"
-                - "some rubbish"
-                - "a/b"
-                - "../../README.md"
-      responses:
-        "207":
-          description: OK, a list of files
-          content:
-            application/json:
-              example:
-                deleted:
-                  - "SysCheck/SAMPLE_SYSCHECK.XML"
-                did_not_exist:
-                  - "some rubbish"
-                  - "a/b"
-                not_allowed:
-                  - "../../README.md"
-                was_used:
-                  - "Unit/SAMPLE_UNIT.XML"
-        "401":
-          description: Not authenticated
-        "403":
-          description: Forbidden
-        "404":
-          description: Workspace not found
-        "409":
-          description: Workspace blocked by another upload or deletion action.
         "410":
           description: Session Expired
         "500":

--- a/e2e/cypress/e2e/Workspace-Admin/files.cy.ts
+++ b/e2e/cypress/e2e/Workspace-Admin/files.cy.ts
@@ -1,6 +1,12 @@
 import {
-  deleteDownloadsFolder, loginSuperAdmin, useTestDB, openSampleWorkspace1,
-  deleteFilesSampleWorkspace, resetBackendData, logoutAdmin, visitLoginPage
+  deleteDownloadsFolder,
+  deleteFilesSampleWorkspace,
+  loginSuperAdmin,
+  logoutAdmin,
+  openSampleWorkspace1,
+  resetBackendData,
+  useTestDB,
+  visitLoginPage
 } from '../utils';
 
 describe('Workspace-Admin-files', () => {
@@ -98,6 +104,42 @@ describe('Workspace-Admin-files', () => {
       .should('exist');
     cy.get('[data-cy="SAMPLE_BOOKLET.XML"]')
       .should('not.exist');
+  });
+
+  it('should be possible to upload any file as a resource', () => {
+    cy.get('[data-cy="uplaod-file-select"]')
+      .selectFile('cypress/fixtures/AnyResource.txt', { force: true });
+    cy.contains('Erfolgreich hochgeladen')
+      .should('exist');
+    cy.contains('AnyResource.txt')
+      .should('exist');
+  });
+
+  it('should be not possible to upload a Testtaker, Booklet, Unit or SysCheck file with the right root but w', () => {
+    cy.get('[data-cy="uplaod-file-select"]')
+      .selectFile('cypress/fixtures/Testtakers_error.xml', { force: true });
+    cy.contains('Abgelehnt')
+      .should('exist');
+    cy.get('[data-cy="close-upload-report"]')
+      .click();
+    cy.get('[data-cy="uplaod-file-select"]')
+      .selectFile('cypress/fixtures/Booklet_error.xml', { force: true });
+    cy.contains('Abgelehnt')
+      .should('exist');
+    cy.get('[data-cy="close-upload-report"]')
+      .click();
+    cy.get('[data-cy="uplaod-file-select"]')
+      .selectFile('cypress/fixtures/Unit_error.xml', { force: true });
+    cy.contains('Abgelehnt')
+      .should('exist');
+    cy.get('[data-cy="close-upload-report"]')
+      .click();
+    cy.get('[data-cy="uplaod-file-select"]')
+      .selectFile('cypress/fixtures/SysCheck_error.xml', { force: true });
+    cy.contains('Abgelehnt')
+      .should('exist');
+    cy.get('[data-cy="close-upload-report"]')
+      .click();
   });
 
   it('should be possible to upload the file SysCheck.xml without any dependencies in other files', () => {

--- a/e2e/cypress/e2e/Workspace-Admin/files.cy.ts
+++ b/e2e/cypress/e2e/Workspace-Admin/files.cy.ts
@@ -1,9 +1,9 @@
 import {
   deleteDownloadsFolder, loginSuperAdmin, useTestDB, openSampleWorkspace1,
   deleteFilesSampleWorkspace, resetBackendData, logoutAdmin, visitLoginPage
-} from './utils';
+} from '../utils';
 
-describe('Workspace-Admin', () => {
+describe('Workspace-Admin-files', () => {
   beforeEach(deleteDownloadsFolder);
   beforeEach(resetBackendData);
   beforeEach(useTestDB);
@@ -469,56 +469,5 @@ describe('Workspace-Admin', () => {
       .should('exist');
     cy.contains('Duplicate Booklet-Id')
       .should('exist');
-  });
-
-  it('should be possible to download a systemcheck summary (csv)', () => {
-    cy.get('[data-cy="System-Check Berichte"]')
-      .click();
-    cy.get('[data-cy="systemcheck-checkbox"]')
-      .click();
-    cy.get('[data-cy="download-button"]')
-      .click();
-    cy.readFile('cypress/downloads/iqb-testcenter-syscheckreports.csv')
-      .should('exist');
-  });
-
-  it('should download the responses of a group', () => {
-    cy.get('[data-cy="Ergebnisse/Antworten"]')
-      .click();
-    cy.get('[data-cy="results-checkbox0"]')
-      .click();
-    cy.get('[data-cy="download-responses"]')
-      .click();
-    cy.readFile('cypress/downloads/iqb-testcenter-responses.csv')
-      .should('exist');
-  });
-
-  it('should download the logs of a group', () => {
-    cy.get('[data-cy="Ergebnisse/Antworten"]')
-      .click();
-    cy.get('[data-cy="results-checkbox0"]')
-      .click();
-    cy.get('[data-cy="download-logs"]')
-      .click();
-    cy.readFile('cypress/downloads/iqb-testcenter-logs.csv')
-      .should('exist');
-  });
-
-  it('should delete the results of a group', () => {
-    cy.get('[data-cy="Ergebnisse/Antworten"]')
-      .click();
-    cy.get('[data-cy="results-checkbox0"]')
-      .click();
-    cy.get('[data-cy="delete-files"]')
-      .click();
-    cy.get('[data-cy="dialog-title"]')
-      .should('exist')
-      .contains('Löschen von Gruppendaten');
-    cy.get('[data-cy="dialog-confirm"]')
-      .should('exist')
-      .contains('Gruppendaten löschen')
-      .click();
-    cy.get('[data-cy="results-checkbox"]')
-      .should('not.exist');
   });
 });

--- a/e2e/cypress/e2e/Workspace-Admin/results.cy.ts
+++ b/e2e/cypress/e2e/Workspace-Admin/results.cy.ts
@@ -1,0 +1,55 @@
+import {
+  deleteDownloadsFolder, loginSuperAdmin, useTestDB, openSampleWorkspace1,
+  resetBackendData, logoutAdmin, visitLoginPage
+} from '../utils';
+
+describe('Workspace-Admin-results', () => {
+  beforeEach(deleteDownloadsFolder);
+  beforeEach(resetBackendData);
+  beforeEach(useTestDB);
+  beforeEach(visitLoginPage);
+  beforeEach(loginSuperAdmin);
+  beforeEach(openSampleWorkspace1);
+
+  afterEach(logoutAdmin);
+
+  it('should download the responses of a group', () => {
+    cy.get('[data-cy="Ergebnisse/Antworten"]')
+      .click();
+    cy.get('[data-cy="results-checkbox0"]')
+      .click();
+    cy.get('[data-cy="download-responses"]')
+      .click();
+    cy.readFile('cypress/downloads/iqb-testcenter-responses.csv')
+      .should('exist');
+  });
+
+  it('should download the logs of a group', () => {
+    cy.get('[data-cy="Ergebnisse/Antworten"]')
+      .click();
+    cy.get('[data-cy="results-checkbox0"]')
+      .click();
+    cy.get('[data-cy="download-logs"]')
+      .click();
+    cy.readFile('cypress/downloads/iqb-testcenter-logs.csv')
+      .should('exist');
+  });
+
+  it('should delete the results of a group', () => {
+    cy.get('[data-cy="Ergebnisse/Antworten"]')
+      .click();
+    cy.get('[data-cy="results-checkbox0"]')
+      .click();
+    cy.get('[data-cy="delete-files"]')
+      .click();
+    cy.get('[data-cy="dialog-title"]')
+      .should('exist')
+      .contains('Löschen von Gruppendaten');
+    cy.get('[data-cy="dialog-confirm"]')
+      .should('exist')
+      .contains('Gruppendaten löschen')
+      .click();
+    cy.get('[data-cy="results-checkbox"]')
+      .should('not.exist');
+  });
+});

--- a/e2e/cypress/e2e/Workspace-Admin/system-check.cy.ts
+++ b/e2e/cypress/e2e/Workspace-Admin/system-check.cy.ts
@@ -1,0 +1,26 @@
+import {
+  deleteDownloadsFolder, loginSuperAdmin, useTestDB, openSampleWorkspace1,
+  resetBackendData, logoutAdmin, visitLoginPage
+} from '../utils';
+
+describe('Workspace-Admin-system', () => {
+  beforeEach(deleteDownloadsFolder);
+  beforeEach(resetBackendData);
+  beforeEach(useTestDB);
+  beforeEach(visitLoginPage);
+  beforeEach(loginSuperAdmin);
+  beforeEach(openSampleWorkspace1);
+
+  afterEach(logoutAdmin);
+
+  it('should be possible to download a systemcheck summary (csv)', () => {
+    cy.get('[data-cy="System-Check Berichte"]')
+      .click();
+    cy.get('[data-cy="systemcheck-checkbox"]')
+      .click();
+    cy.get('[data-cy="download-button"]')
+      .click();
+    cy.readFile('cypress/downloads/iqb-testcenter-syscheckreports.csv')
+      .should('exist');
+  });
+});

--- a/e2e/cypress/fixtures/AnyResource.txt
+++ b/e2e/cypress/fixtures/AnyResource.txt
@@ -1,0 +1,1 @@
+I am some resource.

--- a/e2e/cypress/fixtures/Booklet_error.xml
+++ b/e2e/cypress/fixtures/Booklet_error.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Booklet xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/iqb-berlin/testcenter/15.1.8/definitions/vo_Booklet.xsd">
+  <Metadata-wrong-schema>
+    <Id>BOOKLET.SAMPLE-1</Id>
+    <Label>Sample booklet</Label>
+    <Description>This a sample booklet for testing/development/showcase purposes.</Description>
+  </Metadata-wrong-schema>
+
+</Booklet>

--- a/e2e/cypress/fixtures/SysCheck_error.xml
+++ b/e2e/cypress/fixtures/SysCheck_error.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<SysCheck xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/iqb-berlin/testcenter/15.1.8/definitions/vo_SysCheck.xsd">
+  <Metadata-wrong-schema>
+    <Id>SYSCHECK.SAMPLE</Id>
+    <Label>System-Check Beispiel</Label>
+    <Description>Beschreibungstext für den Systemcheck</Description>
+  </Metadata-wrong-schema>
+
+</SysCheck>

--- a/e2e/cypress/fixtures/Testtakers_error.xml
+++ b/e2e/cypress/fixtures/Testtakers_error.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Testtakers xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/iqb-berlin/testcenter/15.1.8/definitions/vo_Testtakers.xsd">
+
+  <Metadata-wrong-schema>
+    <Description>This file contains some logins for testing and works a a sample for developers.</Description>
+  </Metadata-wrong-schema>
+
+</Testtakers>

--- a/e2e/cypress/fixtures/Unit_error.xml
+++ b/e2e/cypress/fixtures/Unit_error.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<Unit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/iqb-berlin/testcenter/15.1.8/definitions/vo_Unit.xsd">
+  <Metadata-wrong-schema lastChange="2022-10-11T09:30:00+00:00">
+    <Id>UNIT.SAMPLE</Id>
+    <Label>A sample unit</Label>
+    <Description>This is a sample unit showing the possibilities of the sample player.</Description>
+  </Metadata-wrong-schema>
+
+</Unit>

--- a/frontend/src/app/workspace-admin/backend.service.ts
+++ b/frontend/src/app/workspace-admin/backend.service.ts
@@ -122,4 +122,12 @@ export class BackendService {
         )
       );
   }
+
+  getFilesWithDependencies(workspaceId: number, ...files: string[]): Observable<GetFileResponseData> {
+    return this.http
+      .post<GetFileResponseData>(
+      `${this.serverUrl}workspace/${workspaceId}/files-dependencies`,
+      { body: files }
+    );
+  }
 }

--- a/frontend/src/app/workspace-admin/files/files.component.css
+++ b/frontend/src/app/workspace-admin/files/files.component.css
@@ -1,3 +1,11 @@
+.selected-row {
+  background-color: #0080001a;
+}
+
+.isDependency {
+  background-color: rgba(255, 0, 0, 0.1);
+}
+
 .columnhost {
   width: 100%;
   display: flex;
@@ -8,7 +16,7 @@
 }
 
 .filelist {
-  flex:  10 0 400px;
+  flex: 10 0 400px;
   margin-top: 0.7em;
 }
 
@@ -38,7 +46,7 @@ mat-cell:first-of-type, mat-header-cell:first-of-type, mat-footer-cell:first-of-
 }
 
 .sidebar {
-  flex:  10 0 200px;
+  flex: 10 0 200px;
   padding-left: 1em;
 }
 
@@ -50,7 +58,7 @@ mat-cell:first-of-type, mat-header-cell:first-of-type, mat-footer-cell:first-of-
   align-items: center;
 }
 
-.checkerror, .checkwarning, .checkinfo  {
+.checkerror, .checkwarning, .checkinfo {
   margin: 20px;
   font-size: 0.8em;
 }
@@ -82,7 +90,7 @@ mat-cell:first-of-type, mat-header-cell:first-of-type, mat-footer-cell:first-of-
 
 .file-report:hover .full-file-report {
   display: block;
-  position: absolute ;
+  position: absolute;
   background: white;
   box-shadow: 0 3px 1px -2px rgba(0, 0, 0, 0.2), 0 2px 2px 0 rgba(0, 0, 0, 0.14), 0 1px 5px 0 rgba(0, 0, 0, 0.12);
   z-index: 1000;

--- a/frontend/src/app/workspace-admin/files/files.component.html
+++ b/frontend/src/app/workspace-admin/files/files.component.html
@@ -16,10 +16,19 @@
           <mat-table [dataSource]="files[type]" matSort (matSortChange)="setTableSorting($event)">
             <ng-container matColumnDef="checked">
               <mat-header-cell *matHeaderCellDef class="checkboxcell">
-                <mat-checkbox [attr.data-cy]="'files-checkAll-' + type" (change)="checkAll($event.checked, type)"></mat-checkbox>
+                <mat-checkbox
+                  [attr.data-cy]="'files-checkAll-' + type"
+                  (change)="checkAll($event.checked, type)"
+                  [disabled]="!enableInteraction"
+                ></mat-checkbox>
               </mat-header-cell>
               <mat-cell *matCellDef="let element" class="checkboxcell" >
-                <mat-checkbox [attr.data-cy]="'files-checkbox-' + element.id" [checked]="element.isChecked" (change)="element.isChecked=$event.checked"></mat-checkbox>
+                <mat-checkbox
+                  [attr.data-cy]="'files-checkbox-' + element.id"
+                  [checked]="element.isChecked"
+                  (change)="element.isChecked=$event.checked"
+                  [disabled]="!enableInteraction"
+                ></mat-checkbox>
               </mat-cell>
             </ng-container>
 
@@ -80,7 +89,8 @@
             <ng-container matColumnDef="size">
               <mat-header-cell *matHeaderCellDef mat-sort-header> Volle Größe</mat-header-cell>
               <mat-cell *matCellDef="let element" style="white-space: nowrap;">
-                {{ element.info.totalSize | bytes }}
+                <mat-spinner *ngIf="!enableInteraction; else showSize" [diameter]="25" ></mat-spinner>
+                <ng-template #showSize>{{ element.info.totalSize | bytes }}</ng-template>
               </mat-cell>
             </ng-container>
 
@@ -103,10 +113,11 @@
         (click)="deleteFiles()"
         matTooltip="Markierte Dateien löschen"
         matTooltipPosition="above"
-        [disabled]="(wds.wsRole !== 'RW') || !files"
+        [disabled]="(wds.wsRole !== 'RW') || !files || !enableInteraction"
         data-cy="delete-files"
       >
-        <mat-icon>delete</mat-icon>
+        <mat-icon *ngIf="enableInteraction;else deleteSpinner">delete</mat-icon>
+        <ng-template #deleteSpinner><mat-spinner [diameter]="15" ></mat-spinner></ng-template>
         Löschen
       </button>
       <button

--- a/frontend/src/app/workspace-admin/files/files.component.html
+++ b/frontend/src/app/workspace-admin/files/files.component.html
@@ -5,11 +5,11 @@
       <ng-container *ngFor="let type of fileTypes">
         <mat-expansion-panel [expanded]="true" *ngIf="files && files[type].data.length">
           <mat-expansion-panel-header>
-            <mat-panel-title class="table-header">{{typeLabels[type]}}</mat-panel-title>
+            <mat-panel-title class="table-header">{{ typeLabels[type] }}</mat-panel-title>
             <mat-panel-description>
-              <span>{{files[type].data.length}} Datei{{files[type].data.length === 1 ? '' : 'en'}}</span>
-              <span *ngIf="fileStats.invalid[type]">, davon {{fileStats.invalid[type]}} Fehlerhaft</span>
-              <span *ngIf="type=='Testtakers'">, {{fileStats.testtakers}} Teilnehmer</span>
+              <span>{{ files[type].data.length }} Datei{{ files[type].data.length === 1 ? '' : 'en' }}</span>
+              <span *ngIf="fileStats.invalid[type]">, davon {{ fileStats.invalid[type] }} Fehlerhaft</span>
+              <span *ngIf="type=='Testtakers'">, {{ fileStats.testtakers }} Teilnehmer</span>
             </mat-panel-description>
           </mat-expansion-panel-header>
 
@@ -41,14 +41,14 @@
                   <mat-card appearance="raised" class="full-file-report">
                     <mat-card-header *ngIf="element.info.label || element.id">
                       <mat-card-title>
-                        {{element.info.label}}
+                        {{ element.info.label }}
                         <span
-                            *ngIf="element.id !== element.name.toUpperCase()"
-                            style="{{element.info.label ? 'color:silver' : ''}}">
-                        #{{element.id}}
+                          *ngIf="element.id !== element.name.toUpperCase()"
+                          style="{{element.info.label ? 'color:silver' : ''}}">
+                        #{{ element.id }}
                       </span>
                       </mat-card-title>
-                      <mat-card-subtitle>{{element.info.description}}</mat-card-subtitle>
+                      <mat-card-subtitle>{{ element.info.description }}</mat-card-subtitle>
                     </mat-card-header>
                     <mat-card-content>
                       <tc-alert level="info" *ngIf="element.info.testtakers" text="{{element.info.testtakers}} Teilnehmer definiert"></tc-alert>
@@ -64,21 +64,23 @@
             </ng-container>
 
             <ng-container matColumnDef="modificationTime">
-              <mat-header-cell *matHeaderCellDef mat-sort-header class="datecell"> Letzte Änderung </mat-header-cell>
+              <mat-header-cell *matHeaderCellDef mat-sort-header class="datecell"> Letzte Änderung</mat-header-cell>
               <mat-cell *matCellDef="let element" class="datecell">
-                {{(element.modificationTime * 1000) | date: 'dd.MM.yy HH:mm'}}
+                {{ (element.modificationTime * 1000) | date: 'dd.MM.yy HH:mm' }}
               </mat-cell>
             </ng-container>
 
             <ng-container matColumnDef="size">
-              <mat-header-cell *matHeaderCellDef mat-sort-header> Volle Größe  </mat-header-cell>
+              <mat-header-cell *matHeaderCellDef mat-sort-header> Volle Größe</mat-header-cell>
               <mat-cell *matCellDef="let element" style="white-space: nowrap;">
-                {{(element.info.totalSize || element.size) | bytes}}
+                {{ (element.info.totalSize || element.size) | bytes }}
               </mat-cell>
             </ng-container>
 
             <mat-header-row *matHeaderRowDef="displayedColumns"></mat-header-row>
-            <mat-row *matRowDef="let row; columns: displayedColumns;"></mat-row>
+            <mat-row *matRowDef="let row; columns: displayedColumns;" (click)="selectRow($event, row)"
+              [class.selected-row]="selectedRow === row"
+              [class.isDependency]="dependenciesOfRow.includes(row)"></mat-row>
           </mat-table>
 
         </mat-expansion-panel>

--- a/frontend/src/app/workspace-admin/files/files.component.html
+++ b/frontend/src/app/workspace-admin/files/files.component.html
@@ -80,7 +80,7 @@
             <ng-container matColumnDef="size">
               <mat-header-cell *matHeaderCellDef mat-sort-header> Volle Größe</mat-header-cell>
               <mat-cell *matCellDef="let element" style="white-space: nowrap;">
-                {{ (element.info.totalSize || element.size) | bytes }}
+                {{ element.info.totalSize | bytes }}
               </mat-cell>
             </ng-container>
 

--- a/frontend/src/app/workspace-admin/files/files.component.html
+++ b/frontend/src/app/workspace-admin/files/files.component.html
@@ -33,24 +33,28 @@
                       <mat-icon class="report-error">error</mat-icon>
                     </ng-container>
                     <ng-template #noError>
-                      <ng-container *ngIf="element.report.warning && element.report.warning?.length">
+                      <ng-container *ngIf="(element.report.warning && element.report.warning?.length) || !getDependenciesOfFile(element).length">
                         <mat-icon class="report-warning">warning</mat-icon>
                       </ng-container>
                     </ng-template>
                   </span>
-                  <mat-card appearance="raised" class="full-file-report">
+                  <mat-card
+                    *ngIf="element.info.label || (element.id && element.id !== element.name.toUpperCase()) ||
+                    element.info.testtakers || element.report.hasOwnProperty('info') || element.report.hasOwnProperty('warning')
+                    || element.report.hasOwnProperty('error') || !getDependenciesOfFile(element).length"
+                    appearance="raised" class="full-file-report">
                     <mat-card-header *ngIf="element.info.label || element.id">
                       <mat-card-title>
                         {{ element.info.label }}
                         <span
                           *ngIf="element.id !== element.name.toUpperCase()"
                           style="{{element.info.label ? 'color:silver' : ''}}">
-                        #{{ element.id }}
-                      </span>
+                          #{{ element.id }}
+                        </span>
                       </mat-card-title>
                       <mat-card-subtitle>{{ element.info.description }}</mat-card-subtitle>
                     </mat-card-header>
-                    <mat-card-content>
+                    <mat-card-content >
                       <tc-alert level="info" *ngIf="element.info.testtakers" text="{{element.info.testtakers}} Teilnehmer definiert"></tc-alert>
                       <div *ngIf="!getDependenciesOfFile(element).length">
                         <tc-alert [level]="'warning'" [text]="element.type + ' is never used.'"></tc-alert>

--- a/frontend/src/app/workspace-admin/files/files.component.html
+++ b/frontend/src/app/workspace-admin/files/files.component.html
@@ -56,7 +56,7 @@
                     </mat-card-header>
                     <mat-card-content >
                       <tc-alert level="info" *ngIf="element.info.testtakers" text="{{element.info.testtakers}} Teilnehmer definiert"></tc-alert>
-                      <div *ngIf="!getDependenciesOfFile(element).length">
+                      <div *ngIf="!getDependenciesOfFile(element).length && !(element.type == 'SysCheck' || element.type == 'Testtakers')">
                         <tc-alert [level]="'warning'" [text]="element.type + ' is never used.'"></tc-alert>
                       </div>
                       <ng-container *ngFor="let level of ['error', 'warning', 'info']">

--- a/frontend/src/app/workspace-admin/files/files.component.html
+++ b/frontend/src/app/workspace-admin/files/files.component.html
@@ -52,6 +52,9 @@
                     </mat-card-header>
                     <mat-card-content>
                       <tc-alert level="info" *ngIf="element.info.testtakers" text="{{element.info.testtakers}} Teilnehmer definiert"></tc-alert>
+                      <div *ngIf="!getDependenciesOfFile(element).length">
+                        <tc-alert [level]="'warning'" [text]="element.type + ' is never used.'"></tc-alert>
+                      </div>
                       <ng-container *ngFor="let level of ['error', 'warning', 'info']">
                         <div *ngFor="let message of element.report[level]">
                           <tc-alert [level]="level" [text]="message"></tc-alert>

--- a/frontend/src/app/workspace-admin/files/files.component.ts
+++ b/frontend/src/app/workspace-admin/files/files.component.ts
@@ -306,13 +306,20 @@ export class FilesComponent implements OnInit, OnDestroy {
   }
 
   selectRow(event: Event, row: IQBFile) {
-    this.dependenciesOfRow = [];
-    this.selectedRow = this.selectedRow === row ? null : row;
+    if (event.target instanceof HTMLElement && event.target.tagName === 'MAT-CELL') {
+      this.dependenciesOfRow = [];
+      this.selectedRow = this.selectedRow === row ? null : row;
 
-    this.markDependenciesOfRow(row);
+      if (this.selectedRow) {
+        const dependencies = this.getDependenciesOfFile(row);
+        this.dependenciesOfRow = [...dependencies];
+      } else {
+        this.dependenciesOfRow = [];
+      }
+    }
   }
 
-  private markDependenciesOfRow(row: IQBFile) {
+  getDependenciesOfFile(inputFile: IQBFile): IQBFile[] {
     const depTree: { [Type in IQBFileType]: IQBFileType[]; } = {
       Resource: ['Unit', 'Booklet', 'SysCheck', 'Testtakers'],
       Unit: ['Booklet', 'SysCheck', 'Testtakers'],
@@ -320,19 +327,17 @@ export class FilesComponent implements OnInit, OnDestroy {
       SysCheck: [],
       Testtakers: []
     };
+    const result: IQBFile[] = [];
 
-    if (this.selectedRow) {
-      depTree[row.type].forEach(type => {
-        this.files[type].data.forEach(file => {
-          file.dependencies.forEach(dep => {
-            if (dep.object_name === row.name) {
-              this.dependenciesOfRow.push(file);
-            }
-          });
+    depTree[inputFile.type].forEach(type => {
+      this.files[type].data.forEach(file => {
+        file.dependencies.forEach(dep => {
+          if (dep.object_name === inputFile.name) {
+            result.push(file);
+          }
         });
       });
-    } else {
-      this.dependenciesOfRow = [];
-    }
+    });
+    return result;
   }
 }

--- a/frontend/src/app/workspace-admin/files/files.component.ts
+++ b/frontend/src/app/workspace-admin/files/files.component.ts
@@ -189,10 +189,13 @@ export class FilesComponent implements OnInit, OnDestroy {
           this.fileStats = FilesComponent.getStats(fileList);
           this.setTableSorting(this.lastSort);
 
-          const fileListWithFileSize = FilesComponent.calculateFileSize(fileList);
-          IQBFileTypes
-            .forEach(type => {
-              this.files[type] = new MatTableDataSource(fileListWithFileSize[type]);
+          this.bs.getFilesWithDependencies(this.wds.workspaceId, ...IQBFileTypes.map(typehere => fileList[typehere].map(file => file.name)).flat())
+            .subscribe(withDependencies => {
+              const withDependenciesWithFileSize = FilesComponent.calculateFileSize(withDependencies);
+              IQBFileTypes
+                .forEach(type => {
+                  this.files[type] = new MatTableDataSource(withDependenciesWithFileSize[type]);
+                });
             });
         });
     }

--- a/frontend/src/app/workspace-admin/files/files.component.ts
+++ b/frontend/src/app/workspace-admin/files/files.component.ts
@@ -69,6 +69,8 @@ export class FilesComponent implements OnInit, OnDestroy {
   selectedRow: IQBFile | null = null;
   dependenciesOfRow: IQBFile[] = [];
 
+  enableInteraction = true;
+
   private wsIdSubscription: Subscription | null = null;
 
   @ViewChild('fileUploadQueue', { static: true }) uploadQueue!: IqbFilesUploadQueueComponent;
@@ -177,6 +179,7 @@ export class FilesComponent implements OnInit, OnDestroy {
           this.files[type] = new MatTableDataSource();
         });
     } else {
+      this.enableInteraction = false;
       this.bs.getFiles(this.wds.workspaceId)
         .pipe(
           map(fileList => this.addFrontendChecksToFiles(fileList))
@@ -189,13 +192,15 @@ export class FilesComponent implements OnInit, OnDestroy {
           this.fileStats = FilesComponent.getStats(fileList);
           this.setTableSorting(this.lastSort);
 
-          this.bs.getFilesWithDependencies(this.wds.workspaceId, ...IQBFileTypes.map(typehere => fileList[typehere].map(file => file.name)).flat())
+          this.bs.getFilesWithDependencies(this.wds.workspaceId, ...IQBFileTypes.map(typehere => fileList[typehere]?.map(file => file.name)).flat())
             .subscribe(withDependencies => {
               const withDependenciesWithFileSize = FilesComponent.calculateFileSize(withDependencies);
               IQBFileTypes
                 .forEach(type => {
                   this.files[type] = new MatTableDataSource(withDependenciesWithFileSize[type]);
                 });
+
+              this.enableInteraction = true;
             });
         });
     }

--- a/frontend/src/app/workspace-admin/workspace.interfaces.ts
+++ b/frontend/src/app/workspace-admin/workspace.interfaces.ts
@@ -1,4 +1,4 @@
-export const IQBFileTypes = ['Testtakers', 'Booklet', 'SysCheck', 'Resource', 'Unit'] as const;
+export const IQBFileTypes = ['Testtakers', 'Booklet', 'SysCheck', 'Unit', 'Resource'] as const;
 export type IQBFileType = (typeof IQBFileTypes)[number];
 
 export interface IQBFile {
@@ -7,6 +7,10 @@ export interface IQBFile {
   modificationTime: string;
   type: IQBFileType;
   isChecked: boolean;
+  dependencies: {
+    object_name: string;
+    relationship_type: string;
+  }[];
   report: {
     error: string[];
     warning: string[];
@@ -84,3 +88,5 @@ export interface SysCheckStatistics {
   count: number;
   details: string[];
 }
+
+export type FileResponseDataRelationshipType = 'containsUnit' | 'hasBooklet' | 'isDefinedBy' | 'usesPlayer';

--- a/frontend/src/app/workspace-admin/workspace.module.ts
+++ b/frontend/src/app/workspace-admin/workspace.module.ts
@@ -18,6 +18,7 @@ import { MatTooltipModule } from '@angular/material/tooltip';
 import { MatExpansionModule } from '@angular/material/expansion';
 import { MatGridListModule } from '@angular/material/grid-list';
 import { MatProgressBarModule } from '@angular/material/progress-bar';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { SharedModule } from '../shared/shared.module';
 import { BackendService } from './backend.service';
 import { WorkspaceDataService } from './workspacedata.service';
@@ -55,7 +56,8 @@ import {
     MatGridListModule,
     SharedModule,
     MatCardModule,
-    MatProgressBarModule
+    MatProgressBarModule,
+    MatProgressSpinnerModule
   ],
   exports: [
     WorkspaceComponent

--- a/scripts/make/misc.mk
+++ b/scripts/make/misc.mk
@@ -77,6 +77,7 @@ backend-refresh-autoload:
 		-v $(CURDIR)/backend/test:/var/www/backend/test \
 		testcenter-backend-composer \
 		composer dump-autoload --working-dir=/var/www/backend
+	docker compose -f docker/docker-compose.yml -f docker/docker-compose.dev.yml build testcenter-backend
 
 new-version:
 	docker compose -f docker/docker-compose.yml -f docker/docker-compose.dev.yml run \

--- a/scripts/make/test.mk
+++ b/scripts/make/test.mk
@@ -1,3 +1,5 @@
+target ?= .
+
 test-backend-unit:
 	docker compose -f docker/docker-compose.yml -f docker/docker-compose.dev.yml run \
 	--rm --entrypoint "" \
@@ -5,7 +7,7 @@ test-backend-unit:
 		php -dxdebug.mode='debug' /var/www/backend/vendor/phpunit/phpunit/phpunit \
 			--bootstrap /var/www/backend/test/unit/bootstrap.php \
 			--configuration /var/www/backend/phpunit.xml \
-				/var/www/backend/test/unit/. \
+				/var/www/backend/test/unit/$(target) \
 
 
 test-backend-unit-coverage:


### PR DESCRIPTION
solves #498 

Big update on how file uploads are handled.

- upload of single files no longer load in all existing files, but only the needed file types. Leads to much faster upload speeds of single files.
- bulk upload needs less PHP memory_limit as files are not kept in memory at once any longer
- file size calculation and file dependency detection are moved from BE to FE. Both change the burden from read to write - makes uploading of files faster while providing file size and file dependency information asynchronously through FE calculations
- file size calculation and file dependency detection are not persisted anymore - only dynamically calculated

Misc:
- switch middleware order to minimize DB calls for token auth
- add new target argument to make command for unit tests
- automatically apply autoload changes to the backend after autoload-refresh
- add mixed type as argument to cli print-functions