### PR TITLE
sys-check confirmation: set dialog box instead of snackbar for better visibility

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,7 @@ layout: default
 * Wenn es zum Timeout kam, wurde die Sperrung des Workspaces während des uploads wurde nicht mehr korrekt aufgehoben.   
 
 ### Verbesserungen
+* Nach dem Speichern eines SysCheck-Berichts wird ein deutliches Feedback gegeben, dass der Bericht gespeichert wurde. 
 * Beim Ausführen von 'make run' wird nun geprüft, ob sich die Dateien innerhalb der einzelnen workspaces verändert 
   haben, und nur dann werden die Dateien neu importiert. Sollten sich die Dateien zum letzten 'make run' nicht verändert
   haben, so wird kein Datein-Import durchgeführt. Dies beschleunigt die Arbeit in der Entwicklung und auch beim Pflegen

--- a/frontend/src/app/sys-check/report/report.component.ts
+++ b/frontend/src/app/sys-check/report/report.component.ts
@@ -5,6 +5,8 @@ import { BackendService } from '../backend.service';
 import { SysCheckDataService } from '../sys-check-data.service';
 import { SaveReportComponent } from './save-report/save-report.component';
 import { ReportEntry } from '../sys-check.interfaces';
+import { ConfirmDialogComponent } from '../../shared/components/confirm-dialog/confirm-dialog.component';
+import { ConfirmDialogData } from '../../shared/interfaces/confirm-dialog.interfaces';
 
 @Component({
   templateUrl: './report.component.html',
@@ -17,13 +19,13 @@ export class ReportComponent implements OnInit {
   constructor(
     private backendService: BackendService,
     public dataService: SysCheckDataService,
-    private saveDialog: MatDialog,
+    private dialog: MatDialog,
     private snackBar: MatSnackBar
   ) {
   }
 
   saveReport(): void {
-    const dialogRef = this.saveDialog.open(SaveReportComponent, {
+    const dialogRef = this.dialog.open(SaveReportComponent, {
       width: '500px',
       height: '600px'
     });
@@ -44,8 +46,14 @@ export class ReportComponent implements OnInit {
               unit: []
             }
           ).subscribe(() => {
-            this.snackBar.open('Bericht gespeichert.', '', { duration: 3000 });
-            this.isReportSaved = true;
+            this.dialog.open(ConfirmDialogComponent, {
+              width: '400px',
+              data: <ConfirmDialogData>{
+                title: 'Bericht gespeichert',
+                content: 'Der Bericht wurde erfolgreich gespeichert.',
+                confirmbuttonlabel: 'Verstanden'
+              }
+            });
           });
         }
       }


### PR DESCRIPTION
At the end of the system check: The snackbar is replaced with a dialog box for better visibility. 

This change was done after feedback from users suggested visibility as a problem.