### PR TITLE
[bugfix] insert the right pagelabel for reviews

### DIFF
--- a/frontend/src/app/test-controller/components/test-controller/test-controller.component.ts
+++ b/frontend/src/app/test-controller/components/test-controller/test-controller.component.ts
@@ -207,7 +207,7 @@ export class TestControllerComponent implements OnInit, OnDestroy {
           this.tcs.testId,
           (result.target === 'u' || result.target === 'p') ? this.tcs.currentUnitDbKey : null,
           (result.target === 'p') ? this.tcs.currentPageIndex : null,
-          (result.target === 'p') ? this.tcs.currentPageLabel : null,
+          (result.target === 'p') ? result.targetLabel : null,
           result.priority,
           dialogRef.componentInstance.getSelectedCategories(),
           result.sender ? `${result.sender}: ${result.entry}` : result.entry,


### PR DESCRIPTION
- before: the pagelabel was read once, when the review dialog component was opened and never again
- now: the pagelabel is read from the current state of the pagelabel field in the formgroup within the review-dialog component