### PR TITLE
Frontend: Don't remove and reload player between units when it's the same

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,12 @@ layout: default
 * Beim Hochladen einer Testtakers-Datei, die Logins oder Gruppen-Ids verwendet, die bereits auf einem anderen Workspace
   vergeben sind, wie dieser korrekt in der Fehlermeldung benannt.
 
+## [next]
+### Verbesserungen
+* Wenn von einer Unit zu einer anderen navigiert wird, die den gleichen Player (in der gleichen Version) verwendet,
+  wird dieser nicht neu geladen. Dies hat zur Folge, dass z. B. auch GeoGebra nicht neu geladen werden muss, wenn es in
+  zwei Units hintereinander verwendet wird.
+
 ## 15.4.0-beta
 ### neue Features
 * Adaptive Testen, Bonusaufgaben und Filterführung

--- a/frontend/src/app/test-controller/services/test-controller.service.ts
+++ b/frontend/src/app/test-controller/services/test-controller.service.ts
@@ -115,6 +115,14 @@ export class TestControllerService {
   private readonly testStateBuffer$ = new Subject<TestStateUpdate>();
   private readonly subscriptions: { [key: string]: Subscription } = {};
 
+  readonly currentPlayer: {
+    fileName: string;
+    veronaVersion: string;
+  } = {
+      fileName: 'none',
+      veronaVersion: 'none'
+    };
+
   constructor(
     private router: Router,
     private bs: BackendService,


### PR DESCRIPTION
Ich rate immer noch ab, weil ich vermute dass man sich damit bisher unentdeckte Player-Bugs und Quereffekte reinholt, besonders bei weniger ausgiebig getesteten Players and Aspect, aber da MM es seit Jahren fordert, ... kA für welche Version.