### PR TITLE
Backend: Improve booklet validation

### DIFF
--- a/backend/src/files/XMLFileBooklet.class.php
+++ b/backend/src/files/XMLFileBooklet.class.php
@@ -25,7 +25,7 @@ class XMLFileBooklet extends XMLFile {
     ],
     [
       'description' => 'units or alias in from-attribute must be defined',
-      'xpath1' => '//States/State/Option/If/*/@from',
+      'xpath1' => '//States/State/Option/If//*//@from',
       'compare' => 'assertEveryReferredUnitMustBeDefined'
     ]
   ];
@@ -129,10 +129,10 @@ class XMLFileBooklet extends XMLFile {
     array $results2,
     SimpleXMLElement $doc
   ): true | string {
-    $xp = "//Unit[@id = '$unitId'] | //Unit[@alias = '$unitId']";
+    $xp = "//Unit[@id = '$unitId'][not(@alias)] | //Unit[@alias = '$unitId']";
     $findUnit = $doc->xpath($xp);
     if (!$findUnit or !count($findUnit)) {
-      return "No Unit with id or alias `$unitId` defined.";
+      return "No unit with id or alias `$unitId` defined or the id is not unique.";
     }
     return true;
   }

--- a/backend/test/unit/files/XMLFilesBookletTest.php
+++ b/backend/test/unit/files/XMLFilesBookletTest.php
@@ -194,7 +194,7 @@ EOT;
             <If>
               <Median>
                 <Score of="var1" from="i-am-also-not-defined" />
-                <Code of="var2" from="alias" />
+                <Score of="var2" from="alias" />
               </Median>
               <Is greaterThan="50" />
             </If>


### PR DESCRIPTION
closes #701 

When a unit was used more than one time it could still be referred in a condition by its id. An error occurred when running the booklet, but not in the validation.

Also references in nested conditions where not validated correctly.