### PR TITLE
Update MySQL to 8.4

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -27,7 +27,7 @@ variables:
   DOCKER_SERVICE_MTU: 1442
   DOCKER_TLS_CERTDIR: ''
   TRAEFIK_BASE_IMAGE: ${DOCKERHUB_PROXY}traefik:v2.11
-  DB_BASE_IMAGE: ${DOCKERHUB_PROXY}mysql:8.0
+  DB_BASE_IMAGE: ${DOCKERHUB_PROXY}mysql:8.4
   CACHE_SERVICE_BASE_IMAGE: ${DOCKERHUB_PROXY}redis:7.4-bookworm
   TRIVY_IMAGE: ${DOCKER_HUB_PROXY}aquasec/trivy:latest
   PRERELEASE_SCRIPT_REGEX: ^(0|([1-9][0-9]*))\.(0|([1-9][0-9]*))\.(0|([1-9][0-9]*))(-((alpha|beta|rc)((\.)?([1-9][0-9]*))?))$
@@ -964,7 +964,7 @@ test-backend-unit:
         && [[ "$CI_COMMIT_TAG" =~ $RELEASE_SCRIPT_REGEX ]]);
       then
         chmod 0755 scripts/database/000-create-test-db.sh &&
-        docker pull --quiet ${DOCKERHUB_PROXY}mysql:8.0 &&
+        docker pull --quiet ${DOCKERHUB_PROXY}mysql:8.4 &&
         docker pull --quiet ${BACKEND_IMAGE_NAME}:${CI_COMMIT_SHA}_dev &&
         docker tag ${BACKEND_IMAGE_NAME}:${CI_COMMIT_SHA}_dev iqbberlin/testcenter-backend:current &&
         docker compose
@@ -1082,7 +1082,7 @@ test-backend-api:
     TASK_RUNNER_IMAGE_NAME: "${CI_REGISTRY_IMAGE}/task-runner"
   before_script:
     - chmod 0755 scripts/database/000-create-test-db.sh
-    - docker pull --quiet ${DOCKERHUB_PROXY}mysql:8.0
+    - docker pull --quiet ${DOCKERHUB_PROXY}mysql:8.4
     - docker pull --quiet ${DOCKERHUB_PROXY}redis:7.4-bookworm
     - docker pull --quiet ${BACKEND_IMAGE_NAME}:${CI_COMMIT_SHA}_dev
     - docker tag ${BACKEND_IMAGE_NAME}:${CI_COMMIT_SHA}_dev iqbberlin/testcenter-backend:current
@@ -1137,7 +1137,7 @@ test-backend-initialization:
   variables:
     BACKEND_IMAGE_NAME: "${CI_REGISTRY_IMAGE}/iqbberlin/testcenter-backend"
   before_script:
-    - docker pull --quiet ${DOCKERHUB_PROXY}mysql:8.0
+    - docker pull --quiet ${DOCKERHUB_PROXY}mysql:8.4
     - docker pull --quiet ${BACKEND_IMAGE_NAME}:${CI_COMMIT_SHA}_dev
     - docker tag ${BACKEND_IMAGE_NAME}:${CI_COMMIT_SHA}_dev iqbberlin/testcenter-backend:current
   script:
@@ -1211,7 +1211,7 @@ test-e2e:
     - cp frontend/src/environments/environment.dev.ts frontend/src/environments/environment.ts
     - chmod 0755 scripts/database/000-create-test-db.sh
     - docker pull --quiet ${DOCKERHUB_PROXY}traefik:v2.11
-    - docker pull --quiet ${DOCKERHUB_PROXY}mysql:8.0
+    - docker pull --quiet ${DOCKERHUB_PROXY}mysql:8.4
     - docker pull --quiet ${DOCKERHUB_PROXY}redis:7.4-bookworm
     - docker pull --quiet ${BACKEND_IMAGE_NAME}:${CI_COMMIT_SHA}_dev
     - docker tag ${BACKEND_IMAGE_NAME}:${CI_COMMIT_SHA}_dev iqbberlin/testcenter-backend:current

--- a/backend/src/dao/AdminDAO.class.php
+++ b/backend/src/dao/AdminDAO.class.php
@@ -112,7 +112,7 @@ class AdminDAO extends DAO {
 
   public function deleteResultData(int $workspaceId, string $groupName): void {
     $this->_(
-      "delete from login_sessions where group_name = :group_name and workspace_id = :workspace_id",
+      "delete from login_session_groups where group_name = :group_name and workspace_id = :workspace_id",
       [
         ':workspace_id' => $workspaceId,
         ':group_name' => $groupName

--- a/backend/src/dao/DAO.class.php
+++ b/backend/src/dao/DAO.class.php
@@ -6,8 +6,8 @@ class DAO {
   const tables = [ // because we use different types of DB is difficult to get table list by command
     'users',
     'workspaces',
-    'login_sessions',
     'login_session_groups',
+    'login_sessions',
     'person_sessions',
     'tests',
     'units',

--- a/backend/src/dao/SessionDAO.class.php
+++ b/backend/src/dao/SessionDAO.class.php
@@ -457,7 +457,7 @@ class SessionDAO extends DAO {
     );
 
     if (!isset($res['token'])) {
-      throw new Exception("Could not retrieve group token for `{$login->getGroupName()}`.");
+      throw new Exception("Could not retrieve group token for `{$groupName}`.");
     }
 
     return $res['token'];

--- a/backend/src/helper/TestEnvironment.class.php
+++ b/backend/src/helper/TestEnvironment.class.php
@@ -145,7 +145,14 @@ class TestEnvironment {
     $initDAO = new InitDAO();
     $initDAO->clearDB();
     $initDAO->runFile(ROOT_DIR . "/scripts/database/base.sql");
-    $initDAO->installPatches(ROOT_DIR . "/scripts/database/patches.d", false);
+    $report = $initDAO->installPatches(ROOT_DIR . "/scripts/database/patches.d", false);
+    if (count($report['errors'])) {
+      $errors = [];
+      foreach ($report['errors'] as $patch => $error) {
+        $errors[] = "Patch $patch failed with: `$error`";
+      }
+      throw new Exception(implode("; ", $errors));
+    }
 
     $scheme = '-- IQB-Testcenter DB --';
     foreach ($initDAO::tables as $table) {

--- a/backend/test/initialization/docker-compose.initialization-test.yml
+++ b/backend/test/initialization/docker-compose.initialization-test.yml
@@ -76,7 +76,7 @@ services:
       - "85:80"
 
   testcenter-initialization-test-db:
-    image: ${DOCKERHUB_PROXY}mysql:8.0
+    image: ${DOCKERHUB_PROXY}mysql:8.4
     command:
       - "--explicit-defaults-for-timestamp=TRUE"
       - "--sql-mode=PIPES_AS_CONCAT,ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION"

--- a/backend/test/unit/dao/AdminDAOTest.php
+++ b/backend/test/unit/dao/AdminDAOTest.php
@@ -92,7 +92,7 @@ final class AdminDAOTest extends TestCase {
         'bookletname' => 'first sample test',
         'unitname' => 'UNIT_1',
         'laststate' => '{"SOME_STATE":"WHATEVER"}',
-        'originalUnitId' => '',
+        'originalUnitId' => 'UNIT_1',
         'responses' => [
           [
             'id' => "all",
@@ -109,7 +109,7 @@ final class AdminDAOTest extends TestCase {
         'bookletname' => 'first sample test',
         'unitname' => 'UNIT.SAMPLE',
         'laststate' => '{"PRESENTATIONCOMPLETE":"yes"}',
-        'originalUnitId' => '',
+        'originalUnitId' => 'UNIT.SAMPLE',
         'responses' => [
           [
             'id' => "all",
@@ -146,7 +146,7 @@ final class AdminDAOTest extends TestCase {
         'code' => 'xxx',
         'bookletname' => 'first sample test',
         'unitname' => 'UNIT.SAMPLE',
-        'originalUnitId' => '',
+        'originalUnitId' => 'UNIT.SAMPLE',
         'timestamp' => 1597903000,
         'logentry' => 'sample unit log'
       ],
@@ -187,7 +187,7 @@ final class AdminDAOTest extends TestCase {
         'entry' => 'this is a sample unit review',
         'page' => null,
         'pagelabel' => null,
-        'originalUnitId' => '',
+        'originalUnitId' => 'UNIT_1',
         'userAgent' => ''
       ],
       [

--- a/backend/test/unit/dao/SessionDAOTest.php
+++ b/backend/test/unit/dao/SessionDAOTest.php
@@ -436,7 +436,7 @@ class SessionDAOTest extends TestCase {
       "another_one",
       "blablaa",
       "hot-run-restart",
-      "sample_group",
+      "sample_group_first_of_group",
       "Sample Group",
       ['' => ['A.BOOKLET']],
       1,
@@ -446,7 +446,7 @@ class SessionDAOTest extends TestCase {
     $expectation = new LoginSession(
       8,
       'static:login:another_one',
-      'group-token',
+      'static:group:sample_group_first_of_group',
       $anotherLogin
     );
 
@@ -459,6 +459,28 @@ class SessionDAOTest extends TestCase {
 
     $this->assertEquals($expectation, $resultAfter2ndLogin);
     $this->assertEquals(8, $this->countTableRows('login_sessions'));
+
+    $anotherLogin = new Login(
+      "yet_another_one",
+      "blablaa",
+      "hot-run-restart",
+      "sample_group",
+      "Sample Group",
+      ['' => ['A.BOOKLET']],
+      1,
+      946803600
+    );
+
+    $expectation = new LoginSession(
+      10, // 9th row, but MySQL give it ID 10
+      'static:login:yet_another_one',
+      'group-token', // as given in testdata.sql
+      $anotherLogin
+    );
+
+    $result = $this->dbc->createLoginSession($anotherLogin);
+    $this->assertEquals($expectation, $result);
+    $this->assertEquals(9, $this->countTableRows('login_sessions'));
   }
 
   public function test_createLoginSession_groupIdChanged(): void {
@@ -592,7 +614,11 @@ class SessionDAOTest extends TestCase {
   }
 
   public function test_getOrCreateGroupToken(): void {
-    $groupToken = $this->dbc->getOrCreateGroupToken($this->testLoginSession->getLogin());
+    $groupToken = $this->dbc->getOrCreateGroupToken(
+      $this->testLoginSession->getLogin()->getWorkspaceId(),
+      $this->testLoginSession->getLogin()->getGroupName(),
+      $this->testLoginSession->getLogin()->getGroupLabel()
+    );
     $expectation = 'group-token';
     $this->assertEquals($expectation, $groupToken);
   }

--- a/backend/test/unit/test-helper/CreateGroupTokenTask.php
+++ b/backend/test/unit/test-helper/CreateGroupTokenTask.php
@@ -24,6 +24,10 @@ readonly class CreateGroupTokenTask implements Task {
         return parent::_($sql, $replacements, $multiRow);
       }
     };
-    return $slowerSessionDao->getOrCreateGroupToken($this->login);
+    return $slowerSessionDao->getOrCreateGroupToken(
+      $this->login->getWorkspaceId(),
+      $this->login->getGroupName(),
+      $this->login->getGroupLabel()
+    );
   }
 }

--- a/backend/test/unit/testdata.sql
+++ b/backend/test/unit/testdata.sql
@@ -21,6 +21,14 @@ values ('sample_user', 'pw_hash', 'run-hot-return', 1, '{"xxx":["BOOKLET.SAMPLE-
 insert into logins (name, password, mode, workspace_id, codes_to_booklets, source, valid_from, valid_to, valid_for, group_name, group_label, custom_texts)
 values ('future_user', 'pw_hash', 'run-hot-return', 1, '{}', 'testdata.sql', '2030-01-02 10:00:00', '2032-01-02 10:00:00', null, 'sample_group', 'Sample Group', '');
 
+
+insert into login_session_groups (group_label, group_name, token, workspace_id)
+values ('Sample Group', 'sample_group', 'group-token', 1);
+
+insert into login_session_groups (group_label, group_name, token, workspace_id)
+values ('Review Group', 'review_group', 'review-group-token', 1);
+
+
 insert into login_sessions (name, workspace_id, group_name, token)
 values ('test', 1, 'sample_group', 'nice_token');
 
@@ -43,13 +51,6 @@ insert into login_sessions (name, workspace_id, group_name, token)
 values ('test-review', 1, 'review_group', 'nice_token');
 
 
-insert into login_session_groups (group_label, group_name, token, workspace_id)
-values ('Sample Group', 'sample_group', 'group-token', 1);
-
-insert into login_session_groups (group_label, group_name, token, workspace_id)
-values ('Review Group', 'review_group', 'review-group-token', 1);
-
-
 insert into person_sessions(code, login_sessions_id, valid_until, token, name_suffix)
 values ('xxx', 4, '2030-01-02 10:00:00', 'person-token', 'xxx');
 
@@ -65,7 +66,7 @@ values ('', 5, '2032-01-02 10:00:00', 'person-of-future-login-token', '');
 insert into person_sessions(code, login_sessions_id, valid_until, token, name_suffix)
 values ('', 7, '2032-01-02 10:00:00', 'person-of-review-group-token', '');
 
-insert into tests (name, tests.file_id, person_id, laststate, locked, label, running, timestamp_server)
+insert into tests (name, file_id, person_id, laststate, locked, label, running, timestamp_server)
 values ('first sample test', 'first sample test', 1, '{"CURRENT_UNIT_ID":"UNIT_1"}', 0, 'first test label', 1, '2022-01-24 09:01:00');
 
 insert into tests (name, file_id, person_id, laststate, locked, label, running, timestamp_server)
@@ -74,14 +75,14 @@ values ('BOOKLET.SAMPLE-1', 'BOOKLET.SAMPLE-1',1, '', 0, 'second test label', 1,
 insert into tests (name, file_id, person_id, laststate, locked, label, running, timestamp_server)
 values ('BOOKLET.SAMPLE-1#bookletstate=isset', 'BOOKLET.SAMPLE-1', 5, null, 0, 'review test label', 1, '2022-01-24 09:01:00');
 
-insert into units (name, booklet_id, laststate)
-values ('UNIT_1', 1, '{"SOME_STATE":"WHATEVER"}');
+insert into units (name, booklet_id, laststate, original_unit_id)
+values ('UNIT_1', 1, '{"SOME_STATE":"WHATEVER"}', 'UNIT_1');
 
-insert into units (name, booklet_id, laststate)
-values ('UNIT.SAMPLE', 1, '{"PRESENTATIONCOMPLETE":"yes"}');
+insert into units (name, booklet_id, laststate, original_unit_id)
+values ('UNIT.SAMPLE', 1, '{"PRESENTATIONCOMPLETE":"yes"}', 'UNIT.SAMPLE');
 
-insert into units (name, booklet_id, laststate)
-values ('UNIT_1', 3, null);
+insert into units (name, booklet_id, laststate, original_unit_id)
+values ('UNIT_1', 3, null, 'UNIT_1');
 
 insert into unit_logs (unit_id, logentry, timestamp)
 values (2, 'sample unit log', '1597903000');

--- a/docker-compose.prod.tls.yml
+++ b/docker-compose.prod.tls.yml
@@ -95,7 +95,7 @@ services:
       - testcenter_backend_vo_data:/var/www/testcenter/data
 
   testcenter-db:
-    image: ${DOCKERHUB_PROXY}mysql:8.0
+    image: ${DOCKERHUB_PROXY}mysql:8.4
     command:
       - "--explicit-defaults-for-timestamp=TRUE"
       - "--sql-mode=PIPES_AS_CONCAT,ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION"

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -58,7 +58,7 @@ services:
       - testcenter_backend_vo_data:/var/www/testcenter/data
 
   testcenter-db:
-    image: ${DOCKERHUB_PROXY}mysql:8.0
+    image: ${DOCKERHUB_PROXY}mysql:8.4
     command:
       - "--explicit-defaults-for-timestamp=TRUE"
       - "--sql-mode=PIPES_AS_CONCAT,ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -108,7 +108,7 @@ services:
   testcenter-db:
     <<: *restart-policy
     container_name: testcenter-db
-    image: ${DOCKERHUB_PROXY}mysql:8.0
+    image: ${DOCKERHUB_PROXY}mysql:8.4
     environment:
       <<: *env-mysql
       MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,9 @@ layout: default
 ### Accessibility
 * Die Buttons im Starter-Menü sind nun mit der Tab Taste navigierbar
 
+### Sicherheit
+* Upgrade von MySQL 8.0 auf 8.4
+
 ## 16.0.0-alpha
 ### Kubernetes
 * Erste kubernetes-Deployment via Helm möglich. Im Github Release kann das Installationsskript `helm-install-tc.sh` genutzt werden, um die Helm Charts im Kubernetes-Cluster zu installieren.

--- a/scripts/database/patches.d/15.0.0.sql
+++ b/scripts/database/patches.d/15.0.0.sql
@@ -42,8 +42,3 @@ group by
 
 alter table login_sessions
   add index login_sessions_groups_fk (workspace_id, group_name);
-
-alter table login_session_groups
-  add constraint login_sessions_fk
-    foreign key (workspace_id, group_name) references login_sessions (workspace_id, group_name)
-      on delete cascade;

--- a/scripts/database/patches.d/15.4.0.sql
+++ b/scripts/database/patches.d/15.4.0.sql
@@ -7,11 +7,3 @@ alter table tests
   modify name varchar(250) not null;
 
 update tests set file_id = name;
-alter table login_session_groups
-  drop foreign key login_sessions_fk;
-
-alter table login_session_groups
-  add constraint login_sessions_fk
-    foreign key (workspace_id, group_name) references login_sessions (workspace_id, group_name)
-      on update cascade on delete cascade;
-

--- a/scripts/database/patches.d/next.sql
+++ b/scripts/database/patches.d/next.sql
@@ -21,7 +21,4 @@ drop procedure if exists clean_pre_mysql_8_4_key;
 alter table login_sessions
   add constraint login_session_groups_fk
     foreign key (workspace_id, group_name) references login_session_groups (workspace_id, group_name)
-      on delete cascade;
-
-
-
+      on update cascade on delete cascade;

--- a/scripts/database/patches.d/next.sql
+++ b/scripts/database/patches.d/next.sql
@@ -1,0 +1,27 @@
+-- the patch 15.0.0 contained a command, which does not work with MySQL > 8.4
+-- the following procedure would delete this deprecated kind fo key
+
+drop procedure if exists clean_pre_mysql_8_4_key;
+create procedure clean_pre_mysql_8_4_key()
+begin
+  if exists (
+    select * from INFORMATION_SCHEMA.TABLE_CONSTRAINTS
+    where TABLE_SCHEMA = database()
+      and CONSTRAINT_TYPE = 'FOREIGN KEY'
+      and CONSTRAINT_NAME = 'login_sessions_fk'
+  ) then
+    alter table login_session_groups
+      drop constraint login_sessions_fk;
+  end if;
+end;
+call clean_pre_mysql_8_4_key();
+drop procedure if exists clean_pre_mysql_8_4_key;
+
+
+alter table login_sessions
+  add constraint login_session_groups_fk
+    foreign key (workspace_id, group_name) references login_session_groups (workspace_id, group_name)
+      on delete cascade;
+
+
+


### PR DESCRIPTION
Database: Update to MySQL 8.4

This requires a minor change in the db structure because MySQL has become stricter in regard of [certain type of key](https://dev.mysql.com/doc/refman/8.4/en/server-system-variables.html#sysvar_restrict_fk_on_non_standard_key).
The key in question was created by patch 15.0.0. It's purpose was trigger `on delete cascade` and delete a row from `login_session_groups` when every reference to `login_sessions` of this row is gone. The result is, that we can delete all active data (that means data from running studies, not shadowed files, adminusers etc.) by deleting from `user_sessions`.

The new restriction forces us to reverse the reference. To delete active data we now have to delete the group from `login_sessions_group` which is kind od counter-intuitive but actually reflects better database design.

* The key in doubt is removed from the patch 15.0.0.
* An update form a version with that key created by a previous version of that patch, is possible, since MySQL [states](https://dev.mysql.com/doc/refman/8.4/en/mysql-nutshell.html) "Upgrades from MySQL 8.0 are supported even if there are tables containing foreign keys referring to non-unique or partial keys."
  It is removed by the new patch if present.
* A new, reversed patch is created.

closes #683