### PR TITLE
include sampledata/system-test files in build step

### DIFF
--- a/scripts/version.js
+++ b/scripts/version.js
@@ -84,6 +84,11 @@ const updateVersionInFiles = gulp.parallel(
     '$1/$VERSION'
   ),
   replaceInFiles(
+    `${rootPath}/sampledata/system-test/*.xml`,
+    /(xsi:noNamespaceSchemaLocation="https:\/\/raw\.githubusercontent\.com\/iqb-berlin\/testcenter)\/\d+.\d+.\d+(-[\w.]+)?/g,
+    '$1/$VERSION'
+  ),
+  replaceInFiles(
     `${rootPath}/docs/CHANGELOG.md`,
     /## \[next]/g,
     '## $VERSION'


### PR DESCRIPTION
- these files are now included in the create-new-version.sh
- the schemaLocation is now correctly adjusted to the Version number