### PR TITLE
Password Requirements

### DIFF
--- a/backend/initialize.php
+++ b/backend/initialize.php
@@ -217,12 +217,12 @@ try {
   if (!$initDAO->adminExists() and !$args['dont_create_sample_data']) {
     CLI::warning("No Sys-Admin found.");
 
-    $adminId = $initDAO->createAdmin('super', 'user123');
-    CLI::success("Sys-Admin created: `user123`.");
+    $adminId = $initDAO->createAdmin('super', 'Superpasswort-10');
+    CLI::success("Sys-Admin created: `Superpasswort-10`.");
 
     $initDAO->addWorkspacesToAdmin($adminId, $workspaceIds);
     foreach ($workspaceIds as $workspaceId) {
-      CLI::p("Workspace `ws_$workspaceId` added to `user123`.");
+      CLI::p("Workspace `ws_$workspaceId` added to `Superpasswort-10`.");
     }
 
   } else {

--- a/backend/src/helper/Password.class.php
+++ b/backend/src/helper/Password.class.php
@@ -19,17 +19,22 @@ class Password {
 
   static function validate(string $password): void {
     // NIST SP 800-63 recommends longer passwords, at least 8 characters...
-    // to accept the test-account with user123, we take 7 as minimum
+    // Password policy minimum 10 characters, password should contain a mix of letters (uppercase and lowercase), numbers and symbols.
     // 60 is maximum to avoid DDOS attacks based on encryption time.
 
-    if ((strlen($password) < 7)) {
-      throw new HttpError("Password must have at least 7 characters.", 400);
+    if ((strlen($password) < 10)) {
+      throw new HttpError("Password must have at least 10 characters.", 400);
     }
 
     if ((strlen($password) > 60)) {
       // don't let attackers know the maximum too easy
       throw new HttpError("Password too long", 400);
     }
+        
+    if (!preg_match('/^(?=.*[\W])(?=.*[A-Z])(?=.*[a-z])(?=.*[\d])/', $password)) {
+      throw new HttpError("Password should contain a mix of letters (uppercase and lowercase), numbers and symbols.", 400);
+    }
+    
   }
 
   static function verify(string $password, string $hash, string $saltOrPepper): bool {

--- a/frontend/src/app/shared/components/newpassword/new-password.component.html
+++ b/frontend/src/app/shared/components/newpassword/new-password.component.html
@@ -5,7 +5,7 @@
     <div class="infobox">
       <p>Ändern des Kennwortes für "{{ data }}".</p>
     </div>
-    <p>Achtung: Mindestlänge für Kennwort 7 Zeichen</p>
+    <p>Achtung: Das Kennwort sollte eine Mindestlänge von 10 Zeichen und Groß- sowie Kleinbuchstaben, Zahlen und Symbole enthalten.</p>
     <p>
       <mat-form-field class="full-width">
         <input matInput type="password" formControlName="pw" placeholder="Kennwort">

--- a/frontend/src/app/shared/components/newpassword/new-password.component.ts
+++ b/frontend/src/app/shared/components/newpassword/new-password.component.ts
@@ -3,14 +3,16 @@ import { Component, Inject } from '@angular/core';
 import { FormGroup, Validators, FormControl } from '@angular/forms';
 import { samePasswordValidator } from '../../validators/samePassword.validator';
 
+const UpperLowerSymbolNumber = /(?=.*\d)(?=.*[a-z])(?=.*[A-Z])(?=.*\W)/;
+
 @Component({
   templateUrl: './new-password.component.html'
 })
 
 export class NewPasswordComponent {
   newPasswordForm = new FormGroup({
-    pw: new FormControl('', [Validators.required, Validators.minLength(7)]),
-    pw_confirm: new FormControl('', [Validators.required, Validators.minLength(7)])
+    pw: new FormControl('', [Validators.required, Validators.minLength(10), Validators.pattern(UpperLowerSymbolNumber)]),
+    pw_confirm: new FormControl('', [Validators.required, Validators.minLength(10), Validators.pattern(UpperLowerSymbolNumber)])
   },
   { validators: samePasswordValidator }
   );

--- a/frontend/src/app/superadmin/superadmin-password-request/superadmin-password-request.component.ts
+++ b/frontend/src/app/superadmin/superadmin-password-request/superadmin-password-request.component.ts
@@ -2,13 +2,15 @@ import { MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { Component, Inject } from '@angular/core';
 import { FormGroup, Validators, FormControl } from '@angular/forms';
 
+const UpperLowerSymbolNumber = /(?=.*\d)(?=.*[a-z])(?=.*[A-Z])(?=.*\W)/;
+
 @Component({
   templateUrl: './superadmin-password-request.component.html'
 })
 
 export class SuperadminPasswordRequestComponent {
   passwordform = new FormGroup({
-    pw: new FormControl('', [Validators.required, Validators.minLength(7)])
+    pw: new FormControl('', [Validators.required, Validators.minLength(10), Validators.pattern(UpperLowerSymbolNumber)])
   });
 
   constructor(

--- a/frontend/src/app/superadmin/users/newuser/new-user.component.html
+++ b/frontend/src/app/superadmin/users/newuser/new-user.component.html
@@ -7,7 +7,7 @@
         <input data-cy="new-user-name" matInput formControlName="name" placeholder="Name" autocomplete="off">
       </mat-form-field>
     </p>
-    <p>Achtung: Mindestlänge für Kennwort 7 Zeichen</p>
+    <p>Achtung: Das Kennwort sollte eine Mindestlänge von 10 Zeichen und Groß- sowie Kleinbuchstaben, Zahlen und Symbole enthalten.</p>
     <p>
       <mat-form-field class="full-width">
         <input data-cy="new-user-password" matInput type="password" formControlName="pw" placeholder="Kennwort" autocomplete="off">

--- a/frontend/src/app/superadmin/users/newuser/new-user.component.ts
+++ b/frontend/src/app/superadmin/users/newuser/new-user.component.ts
@@ -1,6 +1,8 @@
 import { Component } from '@angular/core';
 import { FormControl, FormGroup, Validators } from '@angular/forms';
 
+const UpperLowerSymbolNumber = /(?=.*\d)(?=.*[a-z])(?=.*[A-Z])(?=.*\W)/;
+
 @Component({
   templateUrl: './new-user.component.html'
 })
@@ -8,6 +10,6 @@ import { FormControl, FormGroup, Validators } from '@angular/forms';
 export class NewUserComponent {
   newUserForm = new FormGroup({
     name: new FormControl('', [Validators.required, Validators.minLength(3)]),
-    pw: new FormControl('', [Validators.required, Validators.minLength(7)])
+    pw: new FormControl('', [Validators.required, Validators.minLength(10), Validators.pattern(UpperLowerSymbolNumber)])
   });
 }


### PR DESCRIPTION
Meets the password requirements for backend and frontend of the Bavarian penetration test (12.08.24)

Passwords must be at least 10 characters long and should contain a mixture of letters (upper and lower case), numbers and symbols.

Attention!
The code requires a **new installation** of the Testcenter. 
It is currently not possible to update a Testcenter version that already has passwords set according to the old guidelines (at least 7 characters) to this version. 
