### PR TITLE
flip the labels of 'leaving page' process

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -21,6 +21,7 @@ layout: default
     * 3 Klicks - Die bisherige Auswahl wird aufgehoben
   * Deselektierung aller Blöcke passiert nicht mehr mit einem Klick auf einen beliebigen Punkt in der angezeigten Tabelle
   * Das Auswählen aller Blöcke bei einem einmaligen Klick sollte nun viel weniger auftreten
+* Die Buttons des Dialogfelds, das erscheint bevor man einen Block zu sperrenden Block verlässt, wurden farblich und textlich verändert, sodass der Default Button nun die Aktion 'Auf der Seite bleiben' darstellt.
 
 ## 16.0.0-alpha
 ### Kubernetes

--- a/frontend/src/app/test-controller/services/test-controller.service.ts
+++ b/frontend/src/app/test-controller/services/test-controller.service.ts
@@ -842,15 +842,16 @@ export class TestControllerService {
       data: <ConfirmDialogData>{
         title: this.cts.getCustomText('booklet_warningLeaveTimerBlockTitle'),
         content: this.cts.getCustomText('booklet_warningLeaveTimerBlockTextPrompt'),
-        confirmbuttonlabel: 'Trotzdem weiter',
+        confirmbuttonlabel: 'Hier bleiben',
         confirmbuttonreturn: true,
+        cancelbuttonlabel: 'Trotzdem weiter',
         showcancel: true
       }
     });
     return dialogCDRef.afterClosed()
       .pipe(
         map(cdresult => {
-          if ((typeof cdresult === 'undefined') || (cdresult === false)) {
+          if ((typeof cdresult === 'undefined') || (cdresult === true)) {
             return false;
           }
           this.cancelTimer(); // does locking the block
@@ -931,15 +932,16 @@ export class TestControllerService {
         data: <ConfirmDialogData>{
           title: this.cts.getCustomText(`booklet_warningLeaveTitle-${lockScope}`),
           content: this.cts.getCustomText(`booklet_warningLeaveTextPrompt-${lockScope}`),
-          confirmbuttonlabel: 'Trotzdem weiter',
+          confirmbuttonlabel: 'Hier bleiben',
           confirmbuttonreturn: true,
+          cancelbuttonlabel: 'Trotzdem weiter',
           showcancel: true
         }
       });
       return dialogCDRef.afterClosed()
         .pipe(
           map(cdresult => {
-            if ((typeof cdresult === 'undefined') || (cdresult === false)) {
+            if ((typeof cdresult === 'undefined') || (cdresult === true)) {
               return false;
             }
             leaveLock();


### PR DESCRIPTION
- the 'stay on page' option is now the colored one
- now incentives to stay on page
- the logic of confirm and cancel is on a label-level flipped