### PR TITLE
fix freezing of browser when calculating file sizes

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,9 @@ layout: default
 ### Verbesserung
 * Wenn die Testleiterkonsole ein SuS über die `Springe zu BLOCK` Funktion in einen zeitgesteuerten Block schiebt, der bereits geschlossen war, so wird dies in den Logs nun mit einem zusätzlichen Hinweis `(closed timeblock reopened)` versehen
 * Beim Springen in einen zeitgesperrten Block muss nun auch die neue Restzeit festgelegt werden, die alle SuS bekommen. Der höchstmögliche Wert richtet sich dabei nach der höchsten eingestellten `timeMax` aller in der Selektion ausgesuchten SuS.
+ 
+### Bugfix
+* Sobald ein Arbeitsplatz im Adminbereich mehr als 1000 Dateien beinhaltet, werden die kumulativen Dateigrößen nicht mehr berechnet, um das Einfrieren des Browsers zu verhindern. Ein Hinweis im Frontend weist darauf hin, dass die Berechnung nicht stattgefunden hat.
 
 ### Accessibility
 * Die Buttons im Starter-Menü sind nun mit der Tab Taste navigierbar

--- a/frontend/src/app/workspace-admin/files/files.component.html
+++ b/frontend/src/app/workspace-admin/files/files.component.html
@@ -90,7 +90,7 @@
               <mat-header-cell *matHeaderCellDef mat-sort-header> Volle Größe</mat-header-cell>
               <mat-cell *matCellDef="let element" style="white-space: nowrap;">
                 <mat-spinner *ngIf="!enableInteraction; else showSize" [diameter]="25" ></mat-spinner>
-                <ng-template #showSize>{{ element.info.totalSize | bytes }}</ng-template>
+                <ng-template #showSize>{{ ((element.info.totalSize | bytes) !== '-') ? (element.info.totalSize | bytes) : 'nicht berechnet' }}</ng-template>
               </mat-cell>
             </ng-container>
 

--- a/frontend/src/app/workspace-admin/files/files.component.ts
+++ b/frontend/src/app/workspace-admin/files/files.component.ts
@@ -196,16 +196,20 @@ export class FilesComponent implements OnInit, OnDestroy {
           this.fileStats = FilesComponent.getStats(fileList);
           this.setTableSorting(this.lastSort);
 
-          this.bs.getFilesWithDependencies(this.wds.workspaceId, ...IQBFileTypes.map(typehere => fileList[typehere]?.map(file => file.name)).flat())
-            .subscribe(withDependencies => {
-              const withDependenciesWithFileSize = FilesComponent.calculateFileSize(withDependencies);
-              IQBFileTypes
-                .forEach(type => {
-                  this.files[type] = new MatTableDataSource(withDependenciesWithFileSize[type]);
-                });
-
-              this.enableInteraction = true;
-            });
+          const files = IQBFileTypes.map(typehere => fileList[typehere]?.map(file => file.name)).flat();
+          if (files.length <= 1000) {
+            this.bs.getFilesWithDependencies(this.wds.workspaceId, ...files)
+              .subscribe(withDependencies => {
+                const withDependenciesWithFileSize = FilesComponent.calculateFileSize(withDependencies);
+                IQBFileTypes
+                  .forEach(type => {
+                    this.files[type] = new MatTableDataSource(withDependenciesWithFileSize[type]);
+                  });
+                this.enableInteraction = true;
+              });
+          } else {
+            this.enableInteraction = true;
+          }
         });
     }
   }
@@ -329,6 +333,7 @@ export class FilesComponent implements OnInit, OnDestroy {
     return result;
   }
 
+  // TODO: Either this algorithm or the whole this.files datastructure could be reworked to allow more files per workspace
   private static calculateFileSize(fileList: GetFileResponseData) {
     const needsToCalculate = IQBFileTypes.filter(type => type !== 'Testtakers' && type !== 'SysCheck' && type !== 'Resource');
 


### PR DESCRIPTION
- when too many files are being calculated, the browser freezes under load
- hard cap at 1000 files; when more files exist, the calculation is skipped with a notice in the frontend