### PR TITLE
set the state, when starting timer

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,7 @@ layout: default
 ### Verbesserung
 * Wenn die Testleiterkonsole ein SuS über die `Springe zu BLOCK` Funktion in einen zeitgesteuerten Block schiebt, der bereits geschlossen war, so wird dies in den Logs nun mit einem zusätzlichen Hinweis `(closed timeblock reopened)` versehen
 * Beim Springen in einen zeitgesperrten Block muss nun auch die neue Restzeit festgelegt werden, die alle SuS bekommen. Der höchstmögliche Wert richtet sich dabei nach der höchsten eingestellten `timeMax` aller in der Selektion ausgesuchten SuS.
+* Die Testleitungskonsole zeigt nun direkt beim betreten in einen zeitbeschränkten Block dessen aktiven Status an, statt erst nach 15 Sekunden
  
 ### Bugfix
 * Sobald ein Arbeitsplatz im Adminbereich mehr als 1000 Dateien beinhaltet, werden die kumulativen Dateigrößen nicht mehr berechnet, um das Einfrieren des Browsers zu verhindern. Ein Hinweis im Frontend weist darauf hin, dass die Berechnung nicht stattgefunden hat.

--- a/frontend/src/app/test-controller/components/test-controller/test-controller.component.ts
+++ b/frontend/src/app/test-controller/components/test-controller/test-controller.component.ts
@@ -251,6 +251,8 @@ export class TestControllerComponent implements OnInit, OnDestroy {
         this.snackBar.open(this.cts.getCustomText('booklet_msgTimerStarted') +
           timer.timeLeftMinString, '', { duration: 5000 });
         this.timerValue = timer;
+        this.tcs.timers[timer.id] = timer.timeLeftSeconds / 60;
+        this.tcs.setTestState('TESTLETS_TIMELEFT', JSON.stringify(this.tcs.timers));
         this.tcs.updateLocks();
         return true;
       case MaxTimerEvent.ENDED:


### PR DESCRIPTION
- set the state with a state change immediately upon starting the timer
- log file now has a row with the maxTime/starttime
- the group monitor immediately shows the current unit, instead of waiting for the first statechange with type 'STEP'