### PR TITLE
Enhance/manage messages from mixed units

### DIFF
--- a/e2e/cypress/e2e/Test-Controller/regression-test-last-unit-state.cy.ts
+++ b/e2e/cypress/e2e/Test-Controller/regression-test-last-unit-state.cy.ts
@@ -1,0 +1,64 @@
+import {
+  forwardTo, getFromIframe,
+  loginTestTaker,
+  resetBackendData,
+  visitLoginPage,
+  getResponses,
+  modifyPlayer
+} from '../utils';
+
+describe('Test Controller', { testIsolation: false }, () => {
+  before(() => {
+    resetBackendData();
+    cy.clearLocalStorage();
+    cy.clearCookies();
+  });
+
+  beforeEach(() => {
+    modifyPlayer([
+      {
+        replace: 'const overridePlayerSettings = (location.search);',
+        with: 'const overridePlayerSettings = "?debounceStateMessages=0&debounceKeyboardEvents=0"'
+      },
+      {
+        replace: 'window.vsp = { PlayerUI, Message, Pages, Log };',
+        with:
+          'window.vsp = { PlayerUI, Message, Pages, Log };' +
+          "window.addEventListener('unload', () => { Message.send._send(Message.send._createStateMsg(true)); });"
+      }
+    ]);
+  });
+
+  it('should not confuse response data if a last package was sent with window:unload', () => {
+    visitLoginPage();
+    loginTestTaker('test', 'user123', 'code-input');
+    cy.get('[formcontrolname="code"]')
+      .type('xxx');
+    cy.get('[data-cy="continue"]')
+      .click();
+    cy.url().should('eq', `${Cypress.config().baseUrl}/#/r/starter`);
+    cy.get('[data-cy="booklet-BOOKLET.SAMPLE-2"]')
+      .click();
+    getFromIframe('#var1')
+      .type('unit 1 - input');
+    cy.wait(1000);
+    forwardTo('Ⓐ Beginner Unit');
+    getFromIframe('#var1')
+      .type('unit 2 - input');
+    cy.wait(1000);
+    getFromIframe('#end-unit')
+      .click();
+    getResponses()
+      .then(rows => {
+        if (!Array.isArray(rows)) throw new Error('wrong response');
+        rows.forEach(row => cy.log(`ROW ${JSON.stringify(row.responses)}`));
+        expect(rows.length).to.equal(3);
+        expect(rows[1].unitname).to.equal('decision-unit');
+        expect(rows[1].responses[0].content[0].id).to.equal('var1');
+        expect(rows[1].responses[0].content[0].value).to.equal('unit 1 - input');
+        expect(rows[2].unitname).to.equal('beginner-unit');
+        expect(rows[2].responses[0].content[0].id).to.equal('var1');
+        expect(rows[2].responses[0].content[0].value).to.equal('unit 2 - input');
+      });
+  });
+});

--- a/e2e/cypress/e2e/utils.ts
+++ b/e2e/cypress/e2e/utils.ts
@@ -43,18 +43,25 @@ export const resetBackendData = (): void => {
 };
 
 export const disableSimplePlayersInternalDebounce = (): void => {
-  const playerSettings = '?debounceStateMessages=0&debounceKeyboardEvents=0';
+  modifyPlayer([{
+    replace: 'const overridePlayerSettings = (location.search);',
+    with: 'const overridePlayerSettings = "?debounceStateMessages=0&debounceKeyboardEvents=0"'
+  }]);
+};
+
+export const modifyPlayer = (rules: { replace: string | RegExp, with: string }[]): void => {
   cy.intercept(
     {
-      url: `${Cypress.env('urls').fileService}/file/static:group:runhotret/ws_1/Resource/verona-player-simple-6.0.html`
+      url: new RegExp(
+        `${Cypress.env('urls').fileService}/file/static:group:[^\\/]+/ws_1/Resource/verona-player-simple-6.0.html`
+      )
     },
     req => {
       req.headers.TestMode = 'integration';
       req.reply(res => {
-        res.body = res.body.replace(
-          /const overridePlayerSettings = (location\.search);/,
-          `const overridePlayerSettings = "${playerSettings}"`
-        );
+        rules.forEach(rule => {
+          res.body = res.body.replace(rule.replace, rule.with);
+        });
       });
     }
   );
@@ -364,5 +371,22 @@ export const reload = () => cy.url()
   .then(url => cy.visit(url.includes('?testMode=true') ? url : `${url}?testMode=true`));
 
 export const expectUnitMenuToBe = (expectations: string[]) => cy.get('[data-cy*="unit-nav-item"]')
-  .each((item, index) => cy.wrap(item).should('have.attr', 'data-cy', `unit-nav-item:${expectations[index]}`)
-  );
+  .each((item, index) => cy.wrap(item).should('have.attr', 'data-cy', `unit-nav-item:${expectations[index]}`));
+
+export const getResponses =
+  (wsId: number = 1, groups: string[] = ['sample_group']) => cy.request({
+    url: `http://localhost/api/workspace/${wsId}/report/response?dataIds=${groups.join('&')}`,
+    method: 'GET',
+    headers: { authToken: 'static:admin:super', testMode: 'integration' }
+  })
+    .then(responses => {
+      expect(responses.status).to.equal(200);
+      if (!Array.isArray(responses.body)) throw new Error('invalid response');
+      responses.body.forEach(row => {
+        row.laststate = JSON.parse(row.laststate);
+        row.responses.forEach(chunk => {
+          chunk.content = JSON.parse(chunk.content);
+        });
+      });
+      return responses.body;
+    });

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -56,7 +56,6 @@
     "@angular/compiler-cli": "~16.1.3",
     "@angular/language-service": "~16.1.3",
     "@compodoc/compodoc": "^1.1.19",
-    "@iqb/eslint-config": "2.1.1",
     "@istanbuljs/nyc-config-typescript": "1.0.2",
     "@types/browserslist-useragent": "^3.0.4",
     "@types/jasminewd2": "~2.0.10",

--- a/frontend/src/app/test-controller/components/unithost/unithost.component.ts
+++ b/frontend/src/app/test-controller/components/unithost/unithost.component.ts
@@ -88,7 +88,7 @@ export class UnithostComponent implements OnInit, OnDestroy {
       // TODO if the session belongs to a previous unit, still handle msg (referring to the that unit, not current)
       // eslint-disable-next-line no-console
       console.warn('wrong player session id: ', msgData.sessionId, msgData);
-      return;
+      // return;
     }
 
     switch (msgType) {

--- a/frontend/src/app/test-controller/components/unithost/unithost.component.ts
+++ b/frontend/src/app/test-controller/components/unithost/unithost.component.ts
@@ -85,6 +85,7 @@ export class UnithostComponent implements OnInit, OnDestroy {
     }
     this.postMessageTarget = messageEvent.source as Window;
     if (msgData.sessionId && (msgSessionId !== this.playerSessionId)) {
+      // TODO if the session belongs to a previous unit, still handle msg (referring to the that unit, not current)
       // eslint-disable-next-line no-console
       console.warn('wrong player session id: ', msgData.sessionId, msgData);
       return;
@@ -291,14 +292,18 @@ export class UnithostComponent implements OnInit, OnDestroy {
   }
 
   private open(unitSequenceId: number): void {
+    while (this.iFrameHostElement.nativeElement.hasChildNodes()) {
+      this.iFrameHostElement.nativeElement.removeChild(this.iFrameHostElement.nativeElement.lastChild);
+    }
+
     this.tcs.currentUnitSequenceId = unitSequenceId;
+
     if (!this.tcs.currentUnit) {
       throw new Error(`No such unit: ${unitSequenceId}`);
     }
 
-    while (this.iFrameHostElement.nativeElement.hasChildNodes()) {
-      this.iFrameHostElement.nativeElement.removeChild(this.iFrameHostElement.nativeElement.lastChild);
-    }
+    this.playerSessionId = Math.floor(Math.random() * 20000000 + 10000000).toString();
+    // TODO playerSessionId should be currenUnit.unitAlias, so messages can be attached to the correct if too late
 
     this.currentPageIndex = -1;
     this.pages = {};
@@ -370,7 +375,7 @@ export class UnithostComponent implements OnInit, OnDestroy {
     }
 
     this.startTimerIfNecessary();
-    this.playerSessionId = Math.floor(Math.random() * 20000000 + 10000000).toString();
+
     this.leaveWarning = false;
     this.prepareIframe();
     this.tcs.updateNavigationState();

--- a/frontend/src/app/test-controller/components/unithost/unithost.component.ts
+++ b/frontend/src/app/test-controller/components/unithost/unithost.component.ts
@@ -6,6 +6,7 @@ import {
 } from '@angular/core';
 import { ActivatedRoute, Params } from '@angular/router';
 import { MatSnackBar } from '@angular/material/snack-bar';
+import { distinctUntilChanged } from 'rxjs/operators';
 import {
   Testlet, LoadingProgress, isUnit, NavigationState, isEqualNavigation
 } from '../../interfaces/test-controller.interfaces';
@@ -18,10 +19,14 @@ import {
   Verona6ValidPages,
   VeronaNavigationDeniedReason,
   VeronaPlayerConfig,
-  VeronaPlayerRuntimeErrorCodes, VeronaUnitState, VopStartCommand
+  VeronaPlayerRuntimeErrorCodes,
+  VeronaUnitState,
+  VopRuntimeErrorNotification,
+  VopStartCommand,
+  VopStateChangedNotification
 } from '../../interfaces/verona.interfaces';
 import { AppError } from '../../../app.interfaces';
-import { distinctUntilChanged } from 'rxjs/operators';
+
 @Component({
   templateUrl: './unithost.component.html',
   styleUrls: ['./unithost.component.css']
@@ -31,10 +36,8 @@ export class UnithostComponent implements OnInit, OnDestroy {
   @ViewChild('iframeHost') private iFrameHostElement!: ElementRef;
   private iFrameItemplayer: HTMLIFrameElement | null = null;
   private subscriptions: { [tag: string ]: Subscription } = {};
-  leaveWarning = false;
-
-  private playerSessionId = '';
   private postMessageTarget: Window = window;
+  leaveWarning = false;
 
   resourcesLoading$: BehaviorSubject<LoadingProgress[]> = new BehaviorSubject<LoadingProgress[]>([]);
   resourcesToLoadLabels: string[] = [];
@@ -79,15 +82,12 @@ export class UnithostComponent implements OnInit, OnDestroy {
     }
     const msgData = messageEvent.data;
     const msgType = msgData.type;
-    let msgSessionId = msgData.sessionId;
-    if ((msgSessionId === undefined) || (msgSessionId === null)) {
-      msgSessionId = this.playerSessionId;
-    }
+
     this.postMessageTarget = messageEvent.source as Window;
-    if (msgData.sessionId && (msgSessionId !== this.playerSessionId)) {
-      // TODO if the session belongs to a previous unit, still handle msg (referring to the that unit, not current)
+    const dontNeedSessionId = ['vopReadyNotification', 'vopWindowFocusChangedNotification'];
+    if ((!dontNeedSessionId.includes(msgType)) && (!(msgData.sessionId in this.tcs.unitAliasMap))) {
       // eslint-disable-next-line no-console
-      console.warn('wrong player session id: ', msgData.sessionId, msgData);
+      console.warn('wrong player session id: ', msgData.sessionId, msgData, this.tcs.unitAliasMap);
       // return;
     }
 
@@ -109,21 +109,7 @@ export class UnithostComponent implements OnInit, OnDestroy {
         break;
 
       case 'vopRuntimeErrorNotification':
-        this.handleRuntimeError(msgData.code, msgData.message);
-        if (this.tcs.testMode.saveResponses) {
-          this.bs.addUnitLog(
-            this.tcs.testId,
-            this.tcs.currentUnit.alias,
-            this.tcs.currentUnit.id,
-            [
-              {
-                key: `Runtime Error: ${msgData.code}`,
-                content: msgData.message || '',
-                timeStamp: Date.now()
-              }
-            ]
-          );
-        }
+        this.handleRuntimeError(msgData);
         break;
 
       default:
@@ -154,11 +140,14 @@ export class UnithostComponent implements OnInit, OnDestroy {
       });
     }
 
-    this.tcs.updateUnitState([{ key: 'PLAYER', timeStamp: Date.now(), content: 'RUNNING' }]);
-
     if (!this.tcs.currentUnit) {
       throw new Error(`Could not start player, because Unit is missing (${this.tcs.currentUnitSequenceId})!`);
     }
+
+    this.tcs.updateUnitState(
+      this.tcs.currentUnit.sequenceId,
+      [{ key: 'PLAYER', timeStamp: Date.now(), content: 'RUNNING' }]
+    );
 
     const unitState: VeronaUnitState = {
       dataParts: this.tcs.currentUnit.dataParts
@@ -175,7 +164,7 @@ export class UnithostComponent implements OnInit, OnDestroy {
 
     const msg: VopStartCommand = {
       type: 'vopStartCommand',
-      sessionId: this.playerSessionId,
+      sessionId: this.tcs.currentUnit.alias,
       unitDefinition: this.tcs.currentUnit.definition,
       unitDefinitionType: this.tcs.currentUnit.unitDefinitionType,
       unitState,
@@ -184,21 +173,22 @@ export class UnithostComponent implements OnInit, OnDestroy {
     this.postMessageTarget.postMessage(msg, '*');
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  private handleStateChangedNotification(msgData: any): void {
-    if (msgData.playerState) {
-      const { playerState } = msgData;
+  private handleStateChangedNotification(msg: VopStateChangedNotification): void {
+    const unit = this.tcs.getUnit(this.tcs.unitAliasMap[msg.sessionId]);
 
-      this.readPages(playerState.validPages);
-      this.currentPageIndex = Object.keys(this.pages).indexOf(playerState.currentPage);
-      if (this.tcs.currentUnit) this.tcs.currentUnit.pageLabels = this.pages;
+    if (msg.playerState) {
+      if (unit.sequenceId === this.tcs.currentUnit?.sequenceId) {
+        this.readPages(msg.playerState.validPages || []);
+        this.currentPageIndex = Object.keys(this.pages).indexOf(msg.playerState.currentPage || '');
+        unit.pageLabels = this.pages;
+      }
 
-      if (typeof playerState.currentPage !== 'undefined') {
-        const pageId: string = String(playerState.currentPage);
+      if (typeof msg.playerState.currentPage !== 'undefined') {
+        const pageId: string = String(msg.playerState.currentPage);
         const pageNr = Object.keys(this.pages).indexOf(pageId) + 1; // human-readable in logs & group monitor
         const pageCount = Object.keys(this.pages).length;
-        if (Object.keys(this.pages).length > 1 && this.pages[playerState.currentPage]) {
-          this.tcs.updateUnitState([
+        if (Object.keys(this.pages).length > 1 && this.pages[msg.playerState.currentPage]) {
+          this.tcs.updateUnitState(unit.sequenceId, [
             { key: 'CURRENT_PAGE_NR', timeStamp: Date.now(), content: pageNr.toString() },
             { key: 'CURRENT_PAGE_ID', timeStamp: Date.now(), content: pageId },
             { key: 'PAGE_COUNT', timeStamp: Date.now(), content: pageCount.toString() }
@@ -206,29 +196,35 @@ export class UnithostComponent implements OnInit, OnDestroy {
         }
       }
     }
-    if (msgData.unitState) {
-      const { unitState } = msgData;
+
+    if (msg.unitState) {
       const timeStamp = Date.now();
 
-      this.tcs.updateUnitState([
-        { key: 'PRESENTATION_PROGRESS', timeStamp, content: unitState.presentationProgress },
-        { key: 'RESPONSE_PROGRESS', timeStamp, content: unitState.responseProgress }
+      this.tcs.updateUnitState(unit.sequenceId, [
+        { key: 'PRESENTATION_PROGRESS', timeStamp, content: msg.unitState.presentationProgress || '' },
+        { key: 'RESPONSE_PROGRESS', timeStamp, content: msg.unitState.responseProgress || '' }
       ]);
 
-      if (unitState?.dataParts) {
+      if (msg.unitState.dataParts) {
         // in pre-verona4-times it was not entirely clear if the stringification of the dataParts should be made
         // by the player itself ot the host. To maintain backwards-compatibility we check this here.
-        Object.keys(unitState.dataParts)
+        Object.keys(msg.unitState.dataParts)
           .forEach(dataPartId => {
-            if (typeof unitState.dataParts[dataPartId] !== 'string') {
-              unitState.dataParts[dataPartId] = JSON.stringify(unitState.dataParts[dataPartId]);
+            if (!msg.unitState || !msg.unitState.dataParts) return;
+            if (typeof msg.unitState.dataParts[dataPartId] !== 'string') {
+              msg.unitState.dataParts[dataPartId] = JSON.stringify(msg.unitState.dataParts[dataPartId]);
             }
           });
-        this.tcs.updateUnitStateDataParts(unitState.dataParts, unitState.unitStateDataType);
+        this.tcs.updateUnitStateDataParts(
+          unit.sequenceId,
+          msg.unitState.dataParts,
+          msg.unitState.unitStateDataType || ''
+        );
       }
     }
-    if (msgData.log && this.tcs.currentUnit) {
-      this.bs.addUnitLog(this.tcs.testId, this.tcs.currentUnit.alias, this.tcs.currentUnit.id, msgData.log);
+
+    if (msg.log) {
+      this.bs.addUnitLog(this.tcs.testId, unit.alias, unit.id, msg.log);
     }
   }
 
@@ -256,7 +252,7 @@ export class UnithostComponent implements OnInit, OnDestroy {
       // Verona 2-5
       this.pages = validPages;
     } else {
-      // Verona > 6
+      // Verona >= 6
       // covers also some versions of aspect who send a corrupted format
       validPages
         .forEach((page, index) => {
@@ -267,7 +263,24 @@ export class UnithostComponent implements OnInit, OnDestroy {
   }
 
   // eslint-disable-next-line class-methods-use-this
-  private handleRuntimeError(code?: string, message?: string): void {
+  private handleRuntimeError(msg: VopRuntimeErrorNotification): void {
+    const unit = (msg.sessionId in this.tcs.unitAliasMap) ?
+      this.tcs.getUnit(this.tcs.unitAliasMap[msg.sessionId]) :
+      this.tcs.currentUnit;
+    if (this.tcs.testMode.saveResponses && unit) {
+      this.bs.addUnitLog(
+        this.tcs.testId,
+        unit.alias,
+        unit.id,
+        [
+          {
+            key: `Runtime Error: ${msg.code}`,
+            content: msg.message || '',
+            timeStamp: Date.now()
+          }
+        ]
+      );
+    }
     // possible reactions on runtimeErrors
     const reactions: { [key: string]: (code: string, message: string) => void } = {
       raiseError: (errorCode, errorMessage) => {
@@ -288,7 +301,7 @@ export class UnithostComponent implements OnInit, OnDestroy {
       'unit-state-type-unsupported': 'raiseError',
       'runtime-error': 'raiseError'
     };
-    reactions[runTimeErrorReactionMap[code || 'runtime-error'] || 'raiseError'](code || '', message || '');
+    reactions[runTimeErrorReactionMap[msg.code || 'runtime-error'] || 'raiseError'](msg.code || '', msg.message || '');
   }
 
   private open(unitSequenceId: number): void {
@@ -301,9 +314,6 @@ export class UnithostComponent implements OnInit, OnDestroy {
     if (!this.tcs.currentUnit) {
       throw new Error(`No such unit: ${unitSequenceId}`);
     }
-
-    this.playerSessionId = Math.floor(Math.random() * 20000000 + 10000000).toString();
-    // TODO playerSessionId should be currenUnit.unitAlias, so messages can be attached to the correct if too late
 
     this.currentPageIndex = -1;
     this.pages = {};
@@ -362,7 +372,10 @@ export class UnithostComponent implements OnInit, OnDestroy {
     this.resourcesLoading$.next([]);
 
     this.tcs.setTestState('CURRENT_UNIT_ID', this.tcs.currentUnit.alias);
-    this.tcs.updateUnitState([{ key: 'PLAYER', timeStamp: Date.now(), content: 'LOADING' }]);
+    this.tcs.updateUnitState(
+      this.tcs.currentUnit.sequenceId,
+      [{ key: 'PLAYER', timeStamp: Date.now(), content: 'LOADING' }]
+    );
     this.runUnit();
   }
 
@@ -468,7 +481,7 @@ export class UnithostComponent implements OnInit, OnDestroy {
   gotoPage(targetPageIndex: number): void {
     this.postMessageTarget?.postMessage({
       type: 'vopPageNavigationCommand',
-      sessionId: this.playerSessionId,
+      sessionId: this.tcs.currentUnit?.alias,
       target: Object.keys(this.pages)[targetPageIndex]
     }, '*');
   }
@@ -482,7 +495,7 @@ export class UnithostComponent implements OnInit, OnDestroy {
 
     this.postMessageTarget.postMessage({
       type: 'vopNavigationDeniedNotification',
-      sessionId: this.playerSessionId,
+      sessionId: this.tcs.currentUnit?.alias,
       reason: navigationDenial.reason
     }, '*');
   }
@@ -520,12 +533,9 @@ export class UnithostComponent implements OnInit, OnDestroy {
   }
 
   private updatePlayerConfig(navigationState: NavigationState): void {
-    if (!this.playerSessionId) {
-      return;
-    }
     this.postMessageTarget.postMessage({
       type: 'vopPlayerConfigChangedNotification',
-      sessionId: this.playerSessionId,
+      sessionId: this.tcs.currentUnit?.alias,
       playerConfig: this.getPlayerConfig(navigationState)
     }, '*');
   }

--- a/frontend/src/app/test-controller/interfaces/verona.interfaces.ts
+++ b/frontend/src/app/test-controller/interfaces/verona.interfaces.ts
@@ -87,3 +87,25 @@ export interface VopStartCommand {
   playerConfig: Verona4PlayerConfig;
   [x: string]: unknown;
 }
+
+export interface VopStateChangedNotification {
+  type: 'vopStateChangedNotification',
+  sessionId: string;
+  playerState?: {
+    validPages?: Verona5ValidPages | Verona6ValidPages;
+    currentPage?: string;
+  },
+  unitState?: VeronaUnitState;
+  log?: {
+    timeStamp: number;
+    content: string;
+    key: string;
+  }[]
+}
+
+export interface VopRuntimeErrorNotification {
+  type: 'vopRuntimeErrorNotification',
+  sessionId: string;
+  message: string;
+  code: string;
+}

--- a/frontend/src/app/test-controller/services/test-controller.service.ts
+++ b/frontend/src/app/test-controller/services/test-controller.service.ts
@@ -303,25 +303,24 @@ export class TestControllerService {
     this.currentTimerId = '';
   }
 
-  updateUnitStateDataParts(dataParts: KeyValuePairString, unitStateDataType: string): void {
-    if (!this.currentUnit) return;
+  updateUnitStateDataParts(unitSequenceId: number, dataParts: KeyValuePairString, unitStateDataType: string): void {
+    const unit = this.getUnit(unitSequenceId);
 
     const changedParts: KeyValuePairString = {};
     Object.keys(dataParts)
       .forEach(dataPartId => {
-        if (!this.currentUnit) return; // ts has forgotten we already checked this
         if (
-          !this.currentUnit.dataParts[dataPartId] ||
-          (this.currentUnit.dataParts[dataPartId] !== dataParts[dataPartId])
+          !unit.dataParts[dataPartId] ||
+          (unit.dataParts[dataPartId] !== dataParts[dataPartId])
         ) {
-          this.currentUnit.dataParts[dataPartId] = dataParts[dataPartId];
+          unit.dataParts[dataPartId] = dataParts[dataPartId];
           changedParts[dataPartId] = dataParts[dataPartId];
         }
       });
     if (Object.keys(changedParts).length) {
       this.unitDataPartsBuffer$.next({
         testId: this.testId,
-        unitAlias: this.currentUnit.alias,
+        unitAlias: unit.alias,
         dataParts: changedParts,
         unitStateDataType
       });
@@ -329,29 +328,27 @@ export class TestControllerService {
     this.updateNavigationState(); // now, not after buffer is closed, because it affects forward/backward, not choice
   }
 
-  updateUnitState(unitStateUpdate: StateReportEntry<UnitStateKey>[]): void {
-    if (!this.currentUnit) return;
+  updateUnitState(unitSequenceId: number, unitStateUpdate: StateReportEntry<UnitStateKey>[]): void {
+    const unit = this.getUnit(unitSequenceId);
 
     const setUnitState = (stateKey: string, value: string): void => {
-      if (!this.currentUnit) return;
       if (stateKey === 'RESPONSE_PROGRESS' && isVeronaProgress(value)) {
-        this.currentUnit.state.RESPONSE_PROGRESS = value;
+        unit.state.RESPONSE_PROGRESS = value;
       }
 
       if (stateKey === 'PRESENTATION_PROGRESS' && isVeronaProgress(value)) {
-        this.currentUnit.state.PRESENTATION_PROGRESS = value;
+        unit.state.PRESENTATION_PROGRESS = value;
       }
 
       if (stateKey === 'CURRENT_PAGE_ID') {
-        this.currentUnit.state.CURRENT_PAGE_ID = value;
+        unit.state.CURRENT_PAGE_ID = value;
       }
     };
 
     const changedStates = unitStateUpdate
       .filter(state => !!state.content)
       .filter(changedState => {
-        if (!this.currentUnit) return false;
-        const oldState = this.currentUnit.state[changedState.key];
+        const oldState = unit.state[changedState.key];
         if (oldState) {
           return oldState !== changedState.content;
         }
@@ -361,7 +358,7 @@ export class TestControllerService {
       .forEach(changedState => setUnitState(changedState.key, changedState.content));
     if (changedStates.length) {
       this.unitStateBuffer$.next({
-        unitAlias: this.currentUnit.alias,
+        unitAlias: unit.alias,
         testId: this.testId,
         state: changedStates
       });
@@ -417,9 +414,9 @@ export class TestControllerService {
 
     if (!unit) {
       // eslint-disable-next-line no-console
-      console.log(`Unit not found:${unitSequenceId}`);
+      console.error(`Unit not found: ${unitSequenceId}`);
       throw new AppError({
-        label: `Unit not found:${unitSequenceId}`,
+        label: `Unit not found: ${unitSequenceId}`,
         description: '',
         type: 'script'
       });

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
   },
   "devDependencies": {
     "@compodoc/compodoc": "^1.1.11",
-    "@iqb/eslint-config": "^2.1.0",
+    "@iqb/eslint-config": "2.1.1",
     "@types/jest": "~27.4.1",
     "dredd": "^14.0.0",
     "eslint-plugin-cypress": "~2.12.1",


### PR DESCRIPTION
Langfristiger (und evtl. ausgiebiger zu testendender) Fix für #847 

Dies sollte auch anderen (bisher unbekannten) Szenarien vorbeugen, in denen Playermessages "verspätet" ankommen.