### PR TITLE
send updateUnitState calls in order, not simultaneously

### DIFF
--- a/frontend/src/app/test-controller/services/test-controller.service.ts
+++ b/frontend/src/app/test-controller/services/test-controller.service.ts
@@ -205,9 +205,8 @@ export class TestControllerService {
         if (!this.testMode.saveResponses) {
           this.bufferEventBus$.next({ type: 'unitState', event: 'saved', id: String(closer) });
         } else {
-          forkJoin(
-            buffer
-              .map(patch => this.bs.patchUnitState(patch, this.units[this.unitAliasMap[patch.unitAlias]].id))
+          from(buffer).pipe(
+            concatMap(patch => this.bs.patchUnitState(patch, this.units[this.unitAliasMap[patch.unitAlias]].id))
           ).subscribe(
             {
               complete: () => this.bufferEventBus$.next({ type: 'unitState', event: 'saved', id: String(closer) })


### PR DESCRIPTION
resolves #860 

-  sometimes multiple state changes arrive in one buffer, unknown in which order those are persisted -> the group monitor received the wrong last Unitstate from the BS
- before: using forkjoin, multiple calls to the backend are made via updateStateChange. Because of race condition, this leads to unpredictable behaviour (you didnt know which state would be the last to be persisted)
- now: using concatMap all stateUpdates are done in order. This is slower but should minimize errors in last state