### PR TITLE
reset the group-monitor component on check-all-toggle

### DIFF
--- a/frontend/src/app/group-monitor/group-monitor.component.ts
+++ b/frontend/src/app/group-monitor/group-monitor.component.ts
@@ -37,6 +37,7 @@ import {
   TimeRestrictionDialogComponent,
   TimeRestrictionDialogData
 } from './time-restriction-dialog/time-restriction-dialog.component';
+import { ComponentUtilService } from '../shared/services/component-util.service';
 
 @Component({
   selector: 'tc-group-monitor',
@@ -89,7 +90,8 @@ export class GroupMonitorComponent implements OnInit, OnDestroy {
     private router: Router,
     private cts: CustomtextService,
     public mds: MainDataService,
-    private addFilterDialog: MatDialog
+    private addFilterDialog: MatDialog,
+    private componentUtilService: ComponentUtilService
   ) {}
 
   ngOnInit(): void {
@@ -341,9 +343,8 @@ export class GroupMonitorComponent implements OnInit, OnDestroy {
 
   toggleAlwaysCheckAll(event: MatSlideToggleChange): void {
     if (this.tsm.checkingOptions.enableAutoCheckAll && event.checked) {
-      this.tsm.checkAll();
-      this.displayOptions.manualChecking = false;
-      this.tsm.checkingOptions.autoCheckAll = true;
+      // TODO not ideal - try to reset the state properly, instead of reloading the component
+      this.componentUtilService.reloadComponent(true);
     } else {
       this.tsm.checkNone();
       this.displayOptions.manualChecking = true;

--- a/frontend/src/app/shared/services/component-util.service.ts
+++ b/frontend/src/app/shared/services/component-util.service.ts
@@ -1,0 +1,21 @@
+import { Injectable } from '@angular/core';
+import { Router } from '@angular/router';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ComponentUtilService {
+  constructor(
+    private router: Router
+  ) { }
+
+  // courtesy of https://javascript.plainenglish.io/angular-how-you-can-reload-refresh-a-single-component-or-the-entire-application-and-reuse-the-logic-c6e975a278c3
+  reloadComponent(self:boolean, urlToNavigateTo ?:string) {
+    const url = self ? this.router.url : urlToNavigateTo;
+    // skipLocationChange:true means don't update the url to / when navigating
+    this.router.navigateByUrl('/', { skipLocationChange: true }).then(() => {
+      this.router.navigate([`/${url}`]).then(() => {
+      });
+    });
+  }
+}

--- a/frontend/src/app/shared/shared.module.ts
+++ b/frontend/src/app/shared/shared.module.ts
@@ -96,3 +96,4 @@ export { BookletConfig } from './classes/booklet-config.class';
 export { TestMode } from './classes/test-mode.class';
 export { customTextDefaults } from './objects/customTextDefaults';
 export * from './interfaces/booklet.interfaces';
+export { ComponentUtilService } from './services/component-util.service';


### PR DESCRIPTION
- Before: when first entering the component, one could control all sessions (even pending). Once the check-all toggle was used, this control off pending sessions disappeared, even when the toggle was activated
- (Temporarily) Fixed: Toggling the switch always reloads the entire group-monitor component, and with it the entire state. Couldnt find the bug in the state change for now