### PR TITLE
Enhance/database

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -29,7 +29,7 @@ variables:
   DOCKER_SERVICE_MTU: 1392
   DOCKER_TLS_CERTDIR: ''
   TRAEFIK_BASE_IMAGE: ${DOCKERHUB_PROXY}traefik:v2.11
-  DB_BASE_IMAGE: ${DOCKERHUB_PROXY}mysql:8.0
+  DB_BASE_IMAGE: ${DOCKERHUB_PROXY}mysql:8.4
   CACHE_SERVICE_BASE_IMAGE: ${DOCKERHUB_PROXY}redis:7.4-bookworm
   TRIVY_IMAGE: ${DOCKER_HUB_PROXY}aquasec/trivy:latest
   JEKYLL_PAGES_IMAGE: "jekyll"
@@ -1001,7 +1001,7 @@ test-backend-unit:
         && [[ "$CI_COMMIT_TAG" =~ $RELEASE_SCRIPT_REGEX ]]);
       then
         chmod 0755 scripts/database/000-create-test-db.sh &&
-        docker pull --quiet ${DOCKERHUB_PROXY}mysql:8.0 &&
+        docker pull --quiet ${DOCKERHUB_PROXY}mysql:8.4 &&
         docker pull --quiet ${BACKEND_IMAGE_NAME}:${CI_COMMIT_SHA}_dev &&
         docker tag ${BACKEND_IMAGE_NAME}:${CI_COMMIT_SHA}_dev iqbberlin/testcenter-backend:current &&
         docker compose
@@ -1119,7 +1119,7 @@ test-backend-api:
     TASK_RUNNER_IMAGE_NAME: "${CI_REGISTRY_IMAGE}/task-runner"
   before_script:
     - chmod 0755 scripts/database/000-create-test-db.sh
-    - docker pull --quiet ${DOCKERHUB_PROXY}mysql:8.0
+    - docker pull --quiet ${DOCKERHUB_PROXY}mysql:8.4
     - docker pull --quiet ${DOCKERHUB_PROXY}redis:7.4-bookworm
     - docker pull --quiet ${BACKEND_IMAGE_NAME}:${CI_COMMIT_SHA}_dev
     - docker tag ${BACKEND_IMAGE_NAME}:${CI_COMMIT_SHA}_dev iqbberlin/testcenter-backend:current
@@ -1174,7 +1174,7 @@ test-backend-initialization:
   variables:
     BACKEND_IMAGE_NAME: "${CI_REGISTRY_IMAGE}/iqbberlin/testcenter-backend"
   before_script:
-    - docker pull --quiet ${DOCKERHUB_PROXY}mysql:8.0
+    - docker pull --quiet ${DOCKERHUB_PROXY}mysql:8.4
     - docker pull --quiet ${BACKEND_IMAGE_NAME}:${CI_COMMIT_SHA}_dev
     - docker tag ${BACKEND_IMAGE_NAME}:${CI_COMMIT_SHA}_dev iqbberlin/testcenter-backend:current
   script:
@@ -1249,7 +1249,7 @@ test-e2e-group-monitor:
     - cp frontend/src/environments/environment.dev.ts frontend/src/environments/environment.ts
     - chmod 0755 scripts/database/000-create-test-db.sh
     - docker pull --quiet ${DOCKERHUB_PROXY}traefik:v2.11
-    - docker pull --quiet ${DOCKERHUB_PROXY}mysql:8.0
+    - docker pull --quiet ${DOCKERHUB_PROXY}mysql:8.4
     - docker pull --quiet ${DOCKERHUB_PROXY}redis:7.4-bookworm
     - docker pull --quiet ${BACKEND_IMAGE_NAME}:${CI_COMMIT_SHA}_dev
     - docker tag ${BACKEND_IMAGE_NAME}:${CI_COMMIT_SHA}_dev iqbberlin/testcenter-backend:current

--- a/.idea/dataSources.xml
+++ b/.idea/dataSources.xml
@@ -14,7 +14,7 @@
       <jdbc-driver>com.mysql.cj.jdbc.Driver</jdbc-driver>
       <jdbc-url>jdbc:mysql://localhost:9091/iqb_tba_testcenter</jdbc-url>
     </data-source>
-    <data-source source="LOCAL" name="Docker | db_TEST" uuid="dd60c978-0a23-422e-abc4-dc13b5b6839f">
+    <data-source source="LOCAL" name="Docker | TEST" uuid="dd60c978-0a23-422e-abc4-dc13b5b6839f">
       <driver-ref>mysql.8</driver-ref>
       <synchronize>true</synchronize>
       <jdbc-driver>com.mysql.cj.jdbc.Driver</jdbc-driver>
@@ -32,6 +32,13 @@
       <synchronize>true</synchronize>
       <jdbc-driver>com.mysql.cj.jdbc.Driver</jdbc-driver>
       <jdbc-url>jdbc:mysql://localhost:3306/TEST_testcenter_monorepo</jdbc-url>
+      <working-dir>$ProjectFileDir$</working-dir>
+    </data-source>
+    <data-source source="LOCAL" name="local | SHIT" uuid="83b756c1-1ac2-46f6-996b-0ce5adb2a0ba">
+      <driver-ref>mysql.8</driver-ref>
+      <synchronize>true</synchronize>
+      <jdbc-driver>com.mysql.cj.jdbc.Driver</jdbc-driver>
+      <jdbc-url>jdbc:mysql://localhost:3306/iqb_tba_testcenter</jdbc-url>
       <working-dir>$ProjectFileDir$</working-dir>
     </data-source>
   </component>

--- a/.idea/sqldialects.xml
+++ b/.idea/sqldialects.xml
@@ -2,5 +2,7 @@
 <project version="4">
   <component name="SqlDialectMappings">
     <file url="file://$PROJECT_DIR$/backend/test/unit/testdata.sql" dialect="MySQL" />
+    <file url="file://$PROJECT_DIR$/scripts/database/full.sql" dialect="MySQL" />
+    <file url="file://$PROJECT_DIR$/scripts/database/patches.d/next.sql" dialect="MySQL" />
   </component>
 </project>

--- a/backend/src/controller/TestController.class.php
+++ b/backend/src/controller/TestController.class.php
@@ -180,8 +180,6 @@ class TestController extends Controller {
       ],
     );
 
-    // TODO check if unit exists in this booklet https://github.com/iqb-berlin/testcenter-iqb-php/issues/106
-
     $priority = (is_numeric($review['priority']) and ($review['priority'] < 4) and ($review['priority'] >= 0))
       ? (int) $review['priority']
       : 0;
@@ -231,15 +229,12 @@ class TestController extends Controller {
       'responseType' => 'unknown'
     ]);
 
-    // TODO check if unit exists in this booklet https://github.com/iqb-berlin/testcenter-iqb-php/issues/106
-
     self::testDAO()->updateDataParts(
       $testId,
       $unitName,
       (array) $unitResponse['dataParts'],
       $unitResponse['responseType'],
-      $unitResponse['timeStamp'],
-      $unitResponse['OriginalUnitId'],
+      $unitResponse['timeStamp']
     );
 
     return $response->withStatus(201);
@@ -251,17 +246,15 @@ class TestController extends Controller {
 
     $testId = (int) $request->getAttribute('test_id');
 
-    $stateData = RequestBodyParser::getElementsFromArray($request, [
+    $statePatch = RequestBodyParser::getElementsFromArray($request, [
       'key' => 'REQUIRED',
       'content' => 'REQUIRED',
       'timeStamp' => 'REQUIRED'
     ]);
 
-    $statePatch = TestController::stateArray2KeyValue($stateData);
-
     $newState = self::testDAO()->updateTestState($testId, $statePatch);
 
-    foreach ($stateData as $entry) {
+    foreach ($statePatch as $entry) {
       self::testDAO()->addTestLog($testId, $entry['key'], $entry['timeStamp'], json_encode($entry['content']));
     }
 
@@ -295,12 +288,10 @@ class TestController extends Controller {
     $testId = (int) $request->getAttribute('test_id');
     $unitName = $request->getAttribute('unit_name');
 
-    // TODO check if unit exists in this booklet https://github.com/iqb-berlin/testcenter-iqb-php/issues/106
-
     $body = JSON::decode($request->getBody()->getContents());
     if (!is_array($body)) {
       // 'not being an array' is the new format
-      $stateData = RequestBodyParser::getElementsFromArray(
+      $statePatch = RequestBodyParser::getElementsFromArray(
         $request,
         [
           'key' => 'REQUIRED',
@@ -312,7 +303,7 @@ class TestController extends Controller {
       $originalUnitId = RequestBodyParser::getElementWithDefault($request, 'originalUnitId', '');
     } else {
       // deprecated
-      $stateData = RequestBodyParser::getElementsFromArray($request, [
+      $statePatch = RequestBodyParser::getElementsFromArray($request, [
         'key' => 'REQUIRED',
         'content' => 'REQUIRED',
         'timeStamp' => 'REQUIRED'
@@ -320,10 +311,9 @@ class TestController extends Controller {
       $originalUnitId = '';
     }
 
-    $statePatch = TestController::stateArray2KeyValue($stateData);
     $newState = self::testDAO()->updateUnitState($testId, $unitName, $statePatch, $originalUnitId);
 
-    foreach ($stateData as $entry) {
+    foreach ($statePatch as $entry) {
       self::testDAO()->addUnitLog(
         $testId,
         $unitName,
@@ -351,7 +341,6 @@ class TestController extends Controller {
     $testId = (int) $request->getAttribute('test_id');
     $unitName = $request->getAttribute('unit_name');
 
-    // TODO check if unit exists in this booklet https://github.com/iqb-berlin/testcenter-iqb-php/issues/106
     if (!is_array(JSON::decode($request->getBody()->getContents()))) {
       // 'not being an array' is the new format
       $logData = RequestBodyParser::getElementsFromArray(
@@ -436,7 +425,7 @@ class TestController extends Controller {
   }
 
   private static function updateTestState(int $testId, array $testSession, string $field, string $value): void {
-    $newState = self::testDAO()->updateTestState($testId, [$field => $value]);
+    $newState = self::testDAO()->updateTestState($testId, [['key' => $field, 'content' => $value, 'timeStamp' => 0]]);
     self::testDAO()->addTestLog($testId, '"' . $field . '"', 0, $value);
 
     $sessionChangeMessage = SessionChangeMessage::testState(
@@ -470,16 +459,5 @@ class TestController extends Controller {
     self::updateTestState($testId, $testSession, 'CONNECTION', 'LOST');
 
     return $response->withStatus(200);
-  }
-
-  // TODO replace this and use proper data-class
-  private static function stateArray2KeyValue(array $stateData): array {
-    $statePatch = [];
-    foreach ($stateData as $stateEntry) {
-      $statePatch[$stateEntry['key']] = is_object($stateEntry['content'])
-        ? json_encode($stateEntry['content'])
-        : $stateEntry['content'];
-    }
-    return $statePatch;
   }
 }

--- a/backend/src/controller/TestController.class.php
+++ b/backend/src/controller/TestController.class.php
@@ -319,8 +319,7 @@ class TestController extends Controller {
         $unitName,
         $entry['key'],
         $entry['timeStamp'],
-        $entry['content'],
-        $originalUnitId
+        $entry['content']
       );
     }
 

--- a/backend/src/dao/AdminDAO.class.php
+++ b/backend/src/dao/AdminDAO.class.php
@@ -268,10 +268,7 @@ class AdminDAO extends DAO {
 
       if ($currentUnitName) {
         $currentUnitState = $this->getUnitState((int) $testSession['test_id'], $currentUnitName);
-
-        if ($currentUnitState) {
-          $sessionChangeMessage->setUnitState($currentUnitName, (array) $currentUnitState);
-        }
+        $sessionChangeMessage->setUnitState($currentUnitName, $currentUnitState);
       }
 
       $sessionChangeMessages->add($sessionChangeMessage);
@@ -280,15 +277,15 @@ class AdminDAO extends DAO {
     return $sessionChangeMessages;
   }
 
-  private function getUnitState(int $testId, string $unitName): stdClass {
+  private function getUnitState(int $testId, string $unitName): array {
     $unitData = $this->_("
       select
-          laststate
+        laststate
       from
-          units
+        units
       where
-          units.test_id = :testId
-          and units.name = :unitName",
+        units.test_id = :testId
+        and units.name = :unitName",
       [
         ':testId' => $testId,
         ':unitName' => $unitName
@@ -296,12 +293,12 @@ class AdminDAO extends DAO {
     );
 
     if (!$unitData) {
-      return (object) [];
+      return [];
     }
 
-    $state = JSON::decode($unitData['laststate'], true) ?? (object) [];
+    $state = JSON::decode($unitData['laststate'], true) ?? [];
 
-    return (object) $state ?? (object) [];
+    return $state ?? [];
   }
 
   public function getResponseReportData($workspaceId, $groups): ?array {

--- a/backend/src/dao/AdminDAO.class.php
+++ b/backend/src/dao/AdminDAO.class.php
@@ -112,7 +112,7 @@ class AdminDAO extends DAO {
 
   public function deleteResultData(int $workspaceId, string $groupName): void {
     $this->_(
-      "delete from login_sessions where group_name = :group_name and workspace_id = :workspace_id",
+      "delete from login_session_groups where group_name = :group_name and workspace_id = :workspace_id",
       [
         ':workspace_id' => $workspaceId,
         ':group_name' => $groupName

--- a/backend/src/dao/AdminDAO.class.php
+++ b/backend/src/dao/AdminDAO.class.php
@@ -287,7 +287,7 @@ class AdminDAO extends DAO {
       from
           units
       where
-          units.booklet_id = :testId
+          units.test_id = :testId
           and units.name = :unitName",
       [
         ':testId' => $testId,
@@ -315,45 +315,55 @@ class AdminDAO extends DAO {
         login_sessions.name as loginname,
         person_sessions.name_suffix as code,
         tests.name as bookletname,
+        tests.id as testId,
         units.name as unitname,
         units.laststate,
-        units.id as unit_id,
         units.original_unit_id as originalUnitId
       from
         login_sessions
           inner join person_sessions on login_sessions.id = person_sessions.login_sessions_id
           inner join tests on person_sessions.id = tests.person_id
-          inner join units on tests.id = units.booklet_id
+          inner join units on tests.id = units.test_id
       where
         login_sessions.workspace_id = ?
           and login_sessions.group_name in ($groupsPlaceholders)
-          and tests.id is not null
+      order by
+        login_sessions.group_name,
+        login_sessions.name,
+        person_sessions.name_suffix,
+        tests.name,
+        units.name,
+        units.original_unit_id
       EOT,
       $bindParams,
       true
     );
 
     foreach ($data as $index => $row) {
-      $data[$index]['responses'] = $this->getResponseDataParts((int) $row['unit_id']);
-      unset($data[$index]['unit_id']);
+      $data[$index]['responses'] = $this->getResponseDataParts($row['unitname'], $row['testId']);
+      unset($data[$index]['testId']);
     }
 
     return $data;
   }
 
-  public function getResponseDataParts(int $unitId): array {
+  public function getResponseDataParts(string $unitName, int $testId): array {
     $data = $this->_(
       'select
-         part_id as id,
-         content,
-         ts,
-         response_type as responseType
-       from
-         unit_data
-       where
-         unit_id = :unit_id',
-      [':unit_id' => $unitId],
-      true
+          part_id as id,
+          content,
+          ts,
+          response_type as responseType
+        from
+          unit_data
+        where
+          unit_name = :unit_name
+          and test_id = :test_id',
+        [
+          ':unit_name' => $unitName,
+          ':test_id' => $testId
+        ],
+        true
     );
     foreach ($data as $index => $row) {
       $data[$index]['ts'] = (int) $row['ts'];
@@ -387,8 +397,9 @@ class AdminDAO extends DAO {
             login_sessions.group_name IN ($groupsPlaceholders) AND
             login_sessions.id = person_sessions.login_sessions_id AND
             person_sessions.id = tests.person_id AND
-            tests.id = units.booklet_id AND
-            units.id = unit_logs.unit_id
+            tests.id = units.test_id AND
+            units.test_id = unit_logs.test_id and 
+            units.name = unit_logs.unit_name
         
         UNION ALL
         
@@ -425,7 +436,7 @@ class AdminDAO extends DAO {
     // TODO: use data class
     return $this->_(
       "
-      SELECT
+      select
         login_sessions.group_name as groupname,
         login_sessions.name as loginname,
         person_sessions.name_suffix as code,
@@ -439,23 +450,19 @@ class AdminDAO extends DAO {
         unit_reviews.pagelabel,
         units.original_unit_id as originalUnitId,
         unit_reviews.user_agent as userAgent
-			FROM
-        login_sessions,
-        person_sessions,
-        tests,
-        units,
+			from
         unit_reviews
-			WHERE
-        login_sessions.workspace_id = ? AND
-        login_sessions.group_name IN ($groupsPlaceholders) AND
-        login_sessions.id = person_sessions.login_sessions_id AND
-        person_sessions.id = tests.person_id AND
-        tests.id = units.booklet_id AND
-        units.id = unit_reviews.unit_id
+        left join units on units.test_id = unit_reviews.test_id and units.name = unit_reviews.unit_name
+        left join tests on tests.id = units.test_id
+        left join person_sessions on person_sessions.id = tests.person_id
+        left join login_sessions on login_sessions.id = person_sessions.login_sessions_id
+			where
+        login_sessions.workspace_id = ? and
+        login_sessions.group_name IN ($groupsPlaceholders)
 			
-			UNION ALL
+			union all
         
-      SELECT
+      select
         login_sessions.group_name as groupname,
         login_sessions.name as loginname,
         person_sessions.name_suffix as code,
@@ -469,17 +476,14 @@ class AdminDAO extends DAO {
         null as pagelabel,
         '' as originalUnitId,
         test_reviews.user_agent as userAgent
-			FROM
-        login_sessions,
-        person_sessions,
-        tests,
+			from
         test_reviews
-			WHERE
-        login_sessions.workspace_id = ? AND
-        login_sessions.group_name IN ($groupsPlaceholders) AND
-        login_sessions.id = person_sessions.login_sessions_id AND
-        person_sessions.id = tests.person_id AND
-        tests.id = test_reviews.booklet_id
+        left join tests on test_reviews.booklet_id = tests.id
+        left join person_sessions on tests.person_id = person_sessions.id
+        left join login_sessions on person_sessions.login_sessions_id = login_sessions.id
+			where
+        login_sessions.workspace_id = ? and
+        login_sessions.group_name IN ($groupsPlaceholders)
 			",
       $bindParams,
       true
@@ -501,7 +505,7 @@ class AdminDAO extends DAO {
         select
           login_sessions.group_name,
           group_label,
-          count(distinct units.id) as num_units,
+          count(distinct units.name, units.test_id) as num_units,
           max(tests.timestamp_server) as timestamp_server
         from
           tests
@@ -510,9 +514,9 @@ class AdminDAO extends DAO {
           inner join login_sessions
             on login_sessions.id = person_sessions.login_sessions_id
           left join units
-            on units.booklet_id = tests.id
+            on units.test_id = tests.id
           left join unit_reviews
-            on units.id = unit_reviews.unit_id
+            on units.name = unit_reviews.unit_name and unit_reviews.test_id = units.test_id
           left join test_reviews
             on tests.id = test_reviews.booklet_id
           left join login_session_groups on 
@@ -622,7 +626,7 @@ class AdminDAO extends DAO {
     if ($attachmentId) {
       list($testId, $unitName, $variableId) = Attachment::decodeId($attachmentId);
       $selectors[] = "tests.id = ?";
-      $selectors[] = "unit_name = ?";
+      $selectors[] = "unit_defs_attachments.unit_name = ?";
       $selectors[] = "variable_id = ?";
       $replacements[] = $testId;
       $replacements[] = $unitName;
@@ -637,12 +641,12 @@ class AdminDAO extends DAO {
                 tests.label as testLabel,
                 tests.id as testId,
                 tests.name as bookletName,
-                unit_name as unitName,
-                unit_name as unitLabel, -- TODO get real unitLabel
+                unit_defs_attachments.unit_name as unitName,
+                unit_defs_attachments.unit_name as unitLabel, -- TODO get real unitLabel
                 variable_id as variableId,
                 attachment_type as attachmentType,
                 unit_data.content as dataPartContent,
-                (tests.id || ':' || unit_name ||  ':' || variable_id) as attachmentId,
+                (tests.id || ':' || unit_defs_attachments.unit_name ||  ':' || variable_id) as attachmentId,
                 unit_data.ts as lastModified
             from
                 unit_defs_attachments
@@ -650,7 +654,7 @@ class AdminDAO extends DAO {
                 left join person_sessions on tests.person_id = person_sessions.id
                 left join login_sessions on person_sessions.login_sessions_id = login_sessions.id
                 left join logins on logins.name = login_sessions.name
-                left join unit_data on part_id = (tests.id || ':' || unit_name || ':' || variable_id)
+                left join unit_data on part_id = (tests.id || ':' || unit_defs_attachments.unit_name || ':' || variable_id)
             where " . implode(' and ', $selectors);
 
     $attachments = $this->_($sql, $replacements, true);

--- a/backend/src/dao/DAO.class.php
+++ b/backend/src/dao/DAO.class.php
@@ -6,8 +6,8 @@ class DAO {
   const tables = [ // because we use different types of DB is difficult to get table list by command
     'users',
     'workspaces',
-    'login_sessions',
     'login_session_groups',
+    'login_sessions',
     'person_sessions',
     'tests',
     'units',

--- a/backend/src/dao/DAO.class.php
+++ b/backend/src/dao/DAO.class.php
@@ -148,7 +148,13 @@ class DAO {
   }
 
   public function beginTransaction(): void {
-    $this->pdoDBhandle->beginTransaction();
+    if (!$this->pdoDBhandle->beginTransaction()) {
+      throw new Exception('PDO: Could not begin Transaction');
+    }
+  }
+
+  public function commitTransaction(): void {
+    $this->pdoDBhandle->commit();
   }
 
   public function rollBack(): void {

--- a/backend/src/dao/InitDAO.class.php
+++ b/backend/src/dao/InitDAO.class.php
@@ -48,6 +48,18 @@ class InitDAO extends SessionDAO {
       'Sample Booklet 1'
     );
     $testDAO->setTestRunning($test->id);
+    $testDAO->updateUnitState(
+      $test->id,
+      "UNIT.SAMPLE",
+      [
+        [
+          "key" => "PRESENTATIONCOMPLETE",
+          "timeStamp" => 1000,
+          "content" => "yes"
+        ]
+      ],
+      "UNIT.SAMPLE"
+    );
     $testDAO->addTestReview(
       $test->id,
       1,
@@ -75,8 +87,16 @@ class InitDAO extends SessionDAO {
       "example-data-format",
       $timestamp
     );
-    $testDAO->updateUnitState($test->id, "UNIT.SAMPLE", ["PRESENTATIONCOMPLETE" => "yes"]);
-    $testDAO->updateTestState($test->id, ["CURRENT_UNIT_ID" => "UNIT.SAMPLE"]);
+    $testDAO->updateTestState(
+      $test->id,
+      [
+        [
+          "key" => "CURRENT_UNIT_ID",
+          "timeStamp" => 1001,
+          "content" => "UNIT.SAMPLE"
+        ]
+      ]
+    );
     $test2 = $testDAO->createTest(
       $personSession->getPerson()->getId(),
       new TestName('BOOKLET.SAMPLE-3'),

--- a/backend/src/dao/SessionDAO.class.php
+++ b/backend/src/dao/SessionDAO.class.php
@@ -457,7 +457,7 @@ class SessionDAO extends DAO {
     );
 
     if (!isset($res['token'])) {
-      throw new Exception("Could not retrieve group token for `{$login->getGroupName()}`.");
+      throw new Exception("Could not retrieve group token for `{$groupName}`.");
     }
 
     return $res['token'];

--- a/backend/src/dao/TestDAO.class.php
+++ b/backend/src/dao/TestDAO.class.php
@@ -349,8 +349,7 @@ class TestDAO extends DAO {
           ':part_id' => $partId,
           ':content' => $content,
           ':ts' => $timestamp,
-          ':response_type' => $type,
-          ':unit_id' => $unitDbId
+          ':response_type' => $type
         ]
       );
     }
@@ -371,8 +370,7 @@ class TestDAO extends DAO {
     string $unitName,
     string $logKey,
     int $timestamp,
-    string $logContent = "",
-    string $originalUnitId = ''
+    string $logContent = ""
   ): void {
     $this->_(
       'insert into unit_logs (unit_name, test_id, logentry, timestamp) values (:unitName, :testId, :logentry, :ts)',

--- a/backend/src/dao/TestDAO.class.php
+++ b/backend/src/dao/TestDAO.class.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 
 class TestDAO extends DAO {
   // TODO unit test
-  public function getTestByPerson(int $personId, string $testName): TestData|null {
+  public function getTestByPerson(int $personId, string $testName): TestData | null {
     $test = $this->_(
       'select tests.locked, tests.name, tests.id, tests.file_id, tests.laststate, tests.label, tests.running from tests
             where tests.person_id=:personId and tests.name=:testname',
@@ -105,7 +105,7 @@ class TestDAO extends DAO {
   // TODO unit test
   public function addUnitReview(
     int $testId,
-    string $unit,
+    string $unitName,
     int $priority,
     string $categories,
     string $entry,
@@ -114,11 +114,22 @@ class TestDAO extends DAO {
     ?int $page = null,
     ?string $pageLabel = null,
   ): void {
-    $unitDbId = $this->getOrCreateUnitId($testId, $unit, $originalUnitId);
     $this->_(
-      'insert into unit_reviews (unit_id, reviewtime, priority, categories, entry, page, pagelabel, user_agent) values(:u, :t, :p, :c, :e, :pa, :pl, :ua)',
+      'insert into unit_reviews (
+            unit_name,
+            test_id,
+            reviewtime,
+            priority,
+            categories,
+            entry,
+            page,
+            pagelabel,
+            user_agent
+        ) values (:unit_name, :test_id, :t, :p, :c, :e, :pa, :pl, :ua)
+          ',
       [
-        ':u' => $unitDbId,
+        ':unit_name' => $unitName,
+        ':test_id' => $testId,
         ':t' => TimeStamp::toSQLFormat(TimeStamp::now()),
         ':p' => $priority,
         ':c' => $categories,
@@ -193,23 +204,24 @@ class TestDAO extends DAO {
     }
 
     $oldState = $testData['laststate'] ? JSON::decode($testData['laststate'], true) : [];
-    $newState = array_merge($oldState, $statePatch);
+    // TODO add column laststate_update_ts analogous to unit_state to avoid race conditions
+    $newState = State::applyPatch($statePatch, $oldState);
 
     $this->_(
       'update tests set laststate = :laststate, timestamp_server = :timestamp where id = :id',
       [
-        ':laststate' => json_encode($newState),
+        ':laststate' => json_encode($newState['newState']),
         ':id' => $testId,
         ':timestamp' => TimeStamp::toSQLFormat(TimeStamp::now())
       ]
     );
 
-    return $newState;
+    return $newState['newState'];
   }
 
   public function getUnitState(int $testId, string $unitName): array {
     $unitData = $this->_(
-      'select units.laststate from units where units.name = :unitname and units.booklet_id = :testId',
+      'select units.laststate from units where units.name = :unitname and units.test_id = :testId',
       [
         ':unitname' => $unitName,
         ':testId' => $testId
@@ -226,28 +238,32 @@ class TestDAO extends DAO {
     array $statePatch,
     string $originalUnitId = ''
   ): array {
-    $unitDbId = $this->getOrCreateUnitId($testId, $unitName, $originalUnitId);
-
     $unitData = $this->_(
-      'select units.laststate from units where units.id=:unitId',
+      'select laststate, laststate_update_ts from units where test_id = :testId and name = :unitName',
       [
-        ':unitId' => $unitDbId
+        ':testId' => $testId,
+        ':unitName' => $unitName
       ]
     );
-
     $oldState = $unitData['laststate'] ? JSON::decode($unitData['laststate'], true) : [];
-    $newState = array_merge($oldState, $statePatch);
+    $oldStateUpdateTs = $unitData['laststate_update_ts'] ? JSON::decode($unitData['laststate_update_ts'], true) : [];
+    $newState = State::applyPatch($statePatch, $oldState, $oldStateUpdateTs);
 
     // todo save states in separate key-value table instead of JSON blob
     $this->_(
-      'update units set laststate = :laststate where id = :id',
+      'insert into units (test_id, name, laststate, laststate_update_ts, original_unit_id)
+      values (:testId, :unitName, :laststate, :laststate_update_ts, :originalUnitId)
+      on duplicate key update laststate = :laststate, laststate_update_ts = :laststate_update_ts;',
       [
-        ':laststate' => json_encode($newState),
-        ':id' => $unitDbId
+        ':laststate' => json_encode($newState['newState']),
+        ':laststate_update_ts' => json_encode($newState['updateTs']),
+        ':testId' => $testId,
+        ':unitName' => $unitName,
+        ':originalUnitId' => $originalUnitId
       ]
     );
 
-    return $newState;
+    return $newState['newState'];
   }
 
   // TODO unit test
@@ -263,60 +279,15 @@ class TestDAO extends DAO {
   }
 
   // TODO unit test
-  public function unlockTest(int $testId): void {
-    $this->changeTestLockStatus($testId, false);
-  }
-
-  // TODO unit test
-  public function locktTest(int $testId): void {
-    $this->changeTestLockStatus($testId, true);
-  }
-
-  private function changeTestLockStatus(int $testId, bool $shouldLock): void {
+  public function changeTestLockStatus(int $testId, bool $unlock = true): void {
     $this->_(
       'update tests set locked = :locked , timestamp_server = :timestamp where id = :id',
       [
-        ':locked' => $shouldLock ? '1' : '0',
+        ':locked' => $unlock ? '0' : '1',
         ':id' => $testId,
         ':timestamp' => TimeStamp::toSQLFormat(TimeStamp::now())
       ]
     );
-  }
-
-  // TODO unit test
-  // todo reduce nr of queries by using replace...into syntax
-  private function getOrCreateUnitId(int $testId, string $unitName, string $originalUnitId = ''): string {
-    $unit = $this->_(
-      'select units.id from units where units.name = :unitname and units.booklet_id = :testId',
-      [
-        ':unitname' => $unitName,
-        ':testId' => $testId
-      ]
-    );
-
-    if ($unit && !empty($originalUnitId)) {
-      $this->_(
-        'update units set original_unit_id = :originalUnitId where id = :unitId',
-        [
-          ':unitId' => $unit['id'],
-          ':originalUnitId' => $originalUnitId
-        ]
-      );
-    }
-
-    if (!$unit) {
-      $this->_(
-        'insert into units (booklet_id, name, original_unit_id) values(:testId, :name, :originalUnitId)',
-        [
-          ':testId' => $testId,
-          ':name' => $unitName,
-          ':originalUnitId' => $originalUnitId
-        ]
-      );
-      return $this->pdoDBhandle->lastInsertId();
-    }
-
-    return (string) $unit['id'];
   }
 
   public function getDataParts(int $testId, string $unitName): array {
@@ -327,10 +298,9 @@ class TestDAO extends DAO {
           unit_data.response_type
         from
           unit_data
-          left join units on units.id = unit_data.unit_id
         where
-          units.name = :unitname
-          and units.booklet_id = :testId
+          unit_data.unit_name = :unitname
+          and unit_data.test_id = :testId
         ',
       [
         ':unitname' => $unitName,
@@ -355,15 +325,19 @@ class TestDAO extends DAO {
     string $unitName,
     array $dataParts,
     string $type,
-    int $timestamp,
-    string $originalUnitId = ''
+    int $timestamp
   ): void {
-    $unitDbId = $this->getOrCreateUnitId($testId, $unitName, $originalUnitId);
     foreach ($dataParts as $partId => $content) {
       $this->_(
-        'replace into unit_data(unit_id, part_id, content, ts, response_type)
-                          values (:unit_id, :part_id, :content, :ts, :response_type)',
+      'insert into unit_data(unit_name, test_id, part_id, content, ts, response_type)
+            values (:unit_name, :test_id, :part_id, :content, :ts, :response_type)
+            on duplicate key update
+              content = if (ts < :ts, :content, content),
+              ts = if (ts < :ts, :ts, ts),
+              response_type = if (ts < :ts, :response_type, response_type);',
         [
+          ':unit_name' => $unitName,
+          ':test_id' => $testId,
           ':part_id' => $partId,
           ':content' => $content,
           ':ts' => $timestamp,
@@ -392,12 +366,11 @@ class TestDAO extends DAO {
     string $logContent = "",
     string $originalUnitId = ''
   ): void {
-    $unitId = $this->getOrCreateUnitId($testId, $unitName, $originalUnitId);
-
     $this->_(
-      'insert into unit_logs (unit_id, logentry, timestamp) values (:unitId, :logentry, :ts)',
+      'insert into unit_logs (unit_name, test_id, logentry, timestamp) values (:unitName, :testId, :logentry, :ts)',
       [
-        ':unitId' => $unitId,
+        ':unitName' => $unitName,
+        ':testId' => $testId,
         ':logentry' => $logKey . ($logContent ? ' = ' . $logContent : ''),
         ':ts' => $timestamp
       ]

--- a/backend/src/dao/TestDAO.class.php
+++ b/backend/src/dao/TestDAO.class.php
@@ -115,6 +115,14 @@ class TestDAO extends DAO {
     ?string $pageLabel = null,
   ): void {
     $this->_(
+      'insert ignore into units (name, test_id, original_unit_id) values(:u, :t, :o)',
+      [
+        ':u' => $unitName,
+        ':t' => $testId,
+        ':o' => $originalUnitId
+      ]
+    );
+    $this->_(
       'insert into unit_reviews (
             unit_name,
             test_id,

--- a/backend/src/data-collection/SessionChangeMessage.class.php
+++ b/backend/src/data-collection/SessionChangeMessage.class.php
@@ -64,17 +64,20 @@ class SessionChangeMessage implements JsonSerializable {
     }
   }
 
-  public function setUnitState(string $unitName, array $unitState) {
+  public function setUnitState(string $unitName, array $unitState): void {
     $this->unitName = $unitName;
     $this->unitState = $unitState;
   }
 
-  public function jsonSerialize(): mixed {
+  public function jsonSerialize(): array {
     $jsonData = [];
 
     foreach ($this as $key => $value) {
       if ($value !== "") {
         $jsonData[$key] = $value;
+      }
+      if ((($key == "testState") or ($key == "unitState")) and (!count($value))) {
+        $jsonData[$key] = (object) [];
       }
     }
 

--- a/backend/src/helper/State.class.php
+++ b/backend/src/helper/State.class.php
@@ -1,0 +1,24 @@
+<?php
+/** @noinspection PhpUnhandledExceptionInspection */
+declare(strict_types=1);
+
+class State {
+  static function applyPatch(array $statePatch, array $oldState = [], array $updateTs = []): array {
+    $newState = $oldState;
+    foreach ($statePatch as $stateEntry) {
+      if (!isset($updateTs[$stateEntry['key']])) {
+        $updateTs[$stateEntry['key']] = 0;
+      }
+      if ($updateTs[$stateEntry['key']] < $stateEntry['timeStamp']) {
+        $updateTs[$stateEntry['key']] = $stateEntry['timeStamp'];
+        $newState[$stateEntry['key']] = is_object($stateEntry['content'])
+          ? json_encode($stateEntry['content'])
+          : $stateEntry['content'];
+      }
+    }
+    return [
+      'newState' => $newState,
+      'updateTs' => $updateTs
+    ];
+  }
+}

--- a/backend/src/helper/TestEnvironment.class.php
+++ b/backend/src/helper/TestEnvironment.class.php
@@ -145,7 +145,14 @@ class TestEnvironment {
     $initDAO = new InitDAO();
     $initDAO->clearDB();
     $initDAO->runFile(ROOT_DIR . "/scripts/database/base.sql");
-    $initDAO->installPatches(ROOT_DIR . "/scripts/database/patches.d", false);
+    $report = $initDAO->installPatches(ROOT_DIR . "/scripts/database/patches.d", false);
+    if (count($report['errors'])) {
+      $errors = [];
+      foreach ($report['errors'] as $patch => $error) {
+        $errors[] = "Patch $patch failed with: `$error`";
+      }
+      throw new Exception(implode("; ", $errors));
+    }
 
     $scheme = '-- IQB-Testcenter DB --';
     foreach ($initDAO::tables as $table) {

--- a/backend/test/initialization/docker-compose.initialization-test.yml
+++ b/backend/test/initialization/docker-compose.initialization-test.yml
@@ -80,7 +80,7 @@ services:
       - "85:80"
 
   testcenter-initialization-test-db:
-    image: ${DOCKERHUB_PROXY}mysql:8.0
+    image: ${DOCKERHUB_PROXY}mysql:8.4
     command:
       - "--explicit-defaults-for-timestamp=TRUE"
       - "--sql-mode=PIPES_AS_CONCAT,ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION"

--- a/backend/test/unit/dao/AdminDAOTest.php
+++ b/backend/test/unit/dao/AdminDAOTest.php
@@ -92,7 +92,7 @@ final class AdminDAOTest extends TestCase {
         'bookletname' => 'first sample test',
         'unitname' => 'UNIT_1',
         'laststate' => '{"SOME_STATE":"WHATEVER"}',
-        'originalUnitId' => '',
+        'originalUnitId' => 'UNIT_1',
         'responses' => [
           [
             'id' => "all",
@@ -109,7 +109,7 @@ final class AdminDAOTest extends TestCase {
         'bookletname' => 'first sample test',
         'unitname' => 'UNIT.SAMPLE',
         'laststate' => '{"PRESENTATIONCOMPLETE":"yes"}',
-        'originalUnitId' => '',
+        'originalUnitId' => 'UNIT.SAMPLE',
         'responses' => [
           [
             'id' => "all",
@@ -146,7 +146,7 @@ final class AdminDAOTest extends TestCase {
         'code' => 'xxx',
         'bookletname' => 'first sample test',
         'unitname' => 'UNIT.SAMPLE',
-        'originalUnitId' => '',
+        'originalUnitId' => 'UNIT.SAMPLE',
         'timestamp' => 1597903000,
         'logentry' => 'sample unit log'
       ],
@@ -187,7 +187,7 @@ final class AdminDAOTest extends TestCase {
         'entry' => 'this is a sample unit review',
         'page' => null,
         'pagelabel' => null,
-        'originalUnitId' => '',
+        'originalUnitId' => 'UNIT_1',
         'userAgent' => ''
       ],
       [

--- a/backend/test/unit/dao/AdminDAOTest.php
+++ b/backend/test/unit/dao/AdminDAOTest.php
@@ -290,7 +290,7 @@ final class AdminDAOTest extends TestCase {
 
     $someTestState = '{"CONTROLLER":"TERMINATED","CONNECTION":"LOST","CURRENT_UNIT_ID":"UNIT.SAMPLE","FOCUS":"HAS","TESTLETS_TIMELEFT":"{\"a_testlet_with_restrictions\":0}"}';
     $this->dbc->_("insert into tests (name, file_id, person_id, locked, running, timestamp_server, laststate) values ('BOOKLET.SAMPLE-2', 'BOOKLET.SAMPLE-2', 1,  0, 1, '2023-11-14 11:13:20', '$someTestState')");
-    $this->dbc->_("insert into units (name, booklet_id) values ('UNIT_1', 4)");
+    $this->dbc->_("insert into units (name, test_id) values ('UNIT_1', 4)");
 
     $expectation = [
       [

--- a/backend/test/unit/dao/AdminDAOTest.php
+++ b/backend/test/unit/dao/AdminDAOTest.php
@@ -368,33 +368,33 @@ final class AdminDAOTest extends TestCase {
         'unitState' => []
       ]
     ];
-    // make order-agnostic
-    usort($expectation, function ($first, $second) {
-      return $first['testId'] <=> $second['testId'];
-    });
+
+    $sessionChangeMessageArray = function(SessionChangeMessage $s): array {
+      $asArray = $s->jsonSerialize();
+      foreach ($asArray as $key => $value) {
+        if ((($key == "testState") or ($key == "unitState")) and (empty((array) $value))) {
+          $asArray[$key] = [];
+        }
+      }
+      return $asArray;
+    };
 
     $result = $this->dbc->getTestSessions(1, ['sample_group']);
-    $resultAsArray = array_map(function (SessionChangeMessage $s) {
-      return $s->jsonSerialize();
-    }, $result->asArray());
+    $resultAsArray = array_map($sessionChangeMessageArray, $result->asArray());
     usort($resultAsArray, function ($first, $second) {
       return $first['testId'] <=> $second['testId'];
     });
     $this->assertSame($expectation, $resultAsArray);
 
     $result = $this->dbc->getTestSessions(1, []); // all groups
-    $resultAsArray = array_map(function (SessionChangeMessage $s) {
-      return $s->jsonSerialize();
-    }, $result->asArray());
+    $resultAsArray = array_map($sessionChangeMessageArray, $result->asArray());
     usort($resultAsArray, function ($first, $second) {
       return $first['testId'] <=> $second['testId'];
     });
     $this->assertSame($expectation, $resultAsArray);
 
     $result = $this->dbc->getTestSessions(1, ['unknown_group']);
-    $resultAsArray = array_map(function (SessionChangeMessage $s) {
-      return $s->jsonSerialize();
-    }, $result->asArray());
+    $resultAsArray = array_map($sessionChangeMessageArray, $result->asArray());
     usort($resultAsArray, function ($first, $second) {
       return $first['testId'] <=> $second['testId'];
     });

--- a/backend/test/unit/dao/SessionDAOTest.php
+++ b/backend/test/unit/dao/SessionDAOTest.php
@@ -436,7 +436,7 @@ class SessionDAOTest extends TestCase {
       "another_one",
       "blablaa",
       "hot-run-restart",
-      "sample_group",
+      "sample_group_first_of_group",
       "Sample Group",
       ['' => ['A.BOOKLET']],
       1,
@@ -446,7 +446,7 @@ class SessionDAOTest extends TestCase {
     $expectation = new LoginSession(
       8,
       'static:login:another_one',
-      'group-token',
+      'static:group:sample_group_first_of_group',
       $anotherLogin
     );
 
@@ -459,6 +459,28 @@ class SessionDAOTest extends TestCase {
 
     $this->assertEquals($expectation, $resultAfter2ndLogin);
     $this->assertEquals(8, $this->countTableRows('login_sessions'));
+
+    $anotherLogin = new Login(
+      "yet_another_one",
+      "blablaa",
+      "hot-run-restart",
+      "sample_group",
+      "Sample Group",
+      ['' => ['A.BOOKLET']],
+      1,
+      946803600
+    );
+
+    $expectation = new LoginSession(
+      10, // 9th row, but MySQL give it ID 10
+      'static:login:yet_another_one',
+      'group-token', // as given in testdata.sql
+      $anotherLogin
+    );
+
+    $result = $this->dbc->createLoginSession($anotherLogin);
+    $this->assertEquals($expectation, $result);
+    $this->assertEquals(9, $this->countTableRows('login_sessions'));
   }
 
   public function test_createLoginSession_groupIdChanged(): void {
@@ -597,7 +619,11 @@ class SessionDAOTest extends TestCase {
   }
 
   public function test_getOrCreateGroupToken(): void {
-    $groupToken = $this->dbc->getOrCreateGroupToken($this->testLoginSession->getLogin());
+    $groupToken = $this->dbc->getOrCreateGroupToken(
+      $this->testLoginSession->getLogin()->getWorkspaceId(),
+      $this->testLoginSession->getLogin()->getGroupName(),
+      $this->testLoginSession->getLogin()->getGroupLabel()
+    );
     $expectation = 'group-token';
     $this->assertEquals($expectation, $groupToken);
   }

--- a/backend/test/unit/helper/StateTest.php
+++ b/backend/test/unit/helper/StateTest.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
+final class StateTest extends TestCase {
+  function test_blub() {
+    $input = '[
+      {
+        "key": "TESTLETS_TIMELEFT",
+        "content": "{\\"Tslt1\\":0}",
+        "timeStamp": 1731064086148
+      },
+      {
+        "key": "TESTLETS_TIMELEFT",
+        "content": "{\\"Tslt1\\":0.75}",
+        "timeStamp": 1731064071064
+      },
+      {
+        "key": "FOCUS",
+        "content": "HAS",
+        "timeStamp": 1731064082010
+      },
+      {
+        "key": "FOCUS",
+        "content": "HAS_NOT",
+        "timeStamp": 1731064084062
+      },
+      {
+        "key": "FOCUS",
+        "content": "HAS",
+        "timeStamp": 1731064085291
+      },
+      {
+        "key": "TESTLETS_TIMELEFT",
+        "content": "{\\"Tslt1\\":0.5}",
+        "timeStamp": 1731064086068
+      },
+
+      {
+        "key": "CONTROLLER",
+        "content": "TERMINATED",
+        "timeStamp": 1731064087942
+      }
+    ]';
+    $inputParsed = JSON::decode($input, true);
+    $output = State::applyPatch($inputParsed);
+    $expectation = [
+      'newState' => [
+        'TESTLETS_TIMELEFT' => '{"Tslt1":0}',
+        'FOCUS' => 'HAS',
+        'CONTROLLER' => 'TERMINATED'
+      ],
+      'updateTs' => [
+        'TESTLETS_TIMELEFT' => 1731064086148,
+        'FOCUS' => 1731064085291,
+        'CONTROLLER' => 1731064087942
+      ]
+    ];
+    $this->assertEquals($expectation, $output);
+  }
+
+
+  function test_blub2() {
+    $input = [
+      [
+        'key' => 'B',
+        'content' => 'B:α',
+        'timeStamp' => 1
+      ],
+      [
+        'key' => 'A',
+        'content' => 'A:α',
+        'timeStamp' => 5
+      ],
+      [
+        'key' => 'B',
+        'content' => 'B:β',
+        'timeStamp' => 0
+      ],
+      [
+        'key' => 'A',
+        'content' => 'A:β',
+        'timeStamp' => 4
+      ],
+      [
+        'key' => 'B',
+        'content' => 'B:γ',
+        'timeStamp' => 2
+      ],
+      [
+        'key' => 'B',
+        'content' => 'B:δ',
+        'timeStamp' => 3
+      ],
+    ];
+    $state = State::applyPatch($input);
+    $expectation = [
+      'newState' => [
+          'A' => 'A:α',
+          'B' => 'B:δ'
+        ],
+      'updateTs' => [
+          'A' => 5,
+          'B' => 3
+        ]
+      ];
+    $this->assertEquals($expectation, $state);
+
+    $secondInput = [
+      [
+        'key' => 'A',
+        'content' => 'ignore me',
+        'timeStamp' => 3
+      ],
+      [
+        'key' => 'B',
+        'content' => 'apply me',
+        'timeStamp' => 7
+      ],
+    ];
+    $state2 = State::applyPatch($secondInput, $state['newState'], $state['updateTs']);
+    $expectation = [
+      'newState' =>  [
+        'A' => 'A:α',
+        'B' => 'apply me'
+      ],
+      'updateTs' => [
+        'A' => 5,
+        'B' => 7
+      ]
+    ];
+    $state = array_merge($state, $state2);
+    $this->assertEquals($expectation, $state);
+  }
+}

--- a/backend/test/unit/test-helper/CreateGroupTokenTask.php
+++ b/backend/test/unit/test-helper/CreateGroupTokenTask.php
@@ -24,6 +24,10 @@ readonly class CreateGroupTokenTask implements Task {
         return parent::_($sql, $replacements, $multiRow);
       }
     };
-    return $slowerSessionDao->getOrCreateGroupToken($this->login);
+    return $slowerSessionDao->getOrCreateGroupToken(
+      $this->login->getWorkspaceId(),
+      $this->login->getGroupName(),
+      $this->login->getGroupLabel()
+    );
   }
 }

--- a/backend/test/unit/testdata.sql
+++ b/backend/test/unit/testdata.sql
@@ -75,17 +75,17 @@ values ('BOOKLET.SAMPLE-1', 'BOOKLET.SAMPLE-1',1, '', 0, 'second test label', 1,
 insert into tests (name, file_id, person_id, laststate, locked, label, running, timestamp_server)
 values ('BOOKLET.SAMPLE-1#bookletstate=isset', 'BOOKLET.SAMPLE-1', 5, null, 0, 'review test label', 1, '2022-01-24 09:01:00');
 
-insert into units (name, booklet_id, laststate, original_unit_id)
+insert into units (name, test_id, laststate, original_unit_id)
 values ('UNIT_1', 1, '{"SOME_STATE":"WHATEVER"}', 'UNIT_1');
 
-insert into units (name, booklet_id, laststate, original_unit_id)
+insert into units (name, test_id, laststate, original_unit_id)
 values ('UNIT.SAMPLE', 1, '{"PRESENTATIONCOMPLETE":"yes"}', 'UNIT.SAMPLE');
 
-insert into units (name, booklet_id, laststate, original_unit_id)
+insert into units (name, test_id, laststate, original_unit_id)
 values ('UNIT_1', 3, null, 'UNIT_1');
 
-insert into unit_logs (unit_id, logentry, timestamp)
-values (2, 'sample unit log', '1597903000');
+insert into unit_logs (unit_name, test_id, logentry, timestamp)
+values ('UNIT.SAMPLE', 1, 'sample unit log', '1597903000');
 
 insert into test_logs (booklet_id, logentry, timestamp)
 values (1, 'sample log entry', 1597903000);
@@ -93,17 +93,17 @@ values (1, 'sample log entry', 1597903000);
 insert into test_reviews (booklet_id, reviewtime, priority, categories, entry, user_agent)
 values (3, '2030-01-01 12:00:00', 1, '', 'sample booklet review', '');
 
-insert into unit_reviews (unit_id, reviewtime, priority, categories, entry, page, pagelabel, user_agent)
-values (3, '2030-01-01 12:00:00', 1, '', 'this is a sample unit review', null, null, '');
+insert into unit_reviews (unit_name, test_id, reviewtime, priority, categories, entry, page, pagelabel, user_agent)
+values ('UNIT_1', 3, '2030-01-01 12:00:00', 1, '', 'this is a sample unit review', null, null, '');
 
-insert into unit_data (unit_id, part_id, content, ts, response_type)
-values (1, 'all', '{"name":"Sam Sample","age":34}', 1597903000, 'the-response-type');
+insert into unit_data (unit_name, test_id, part_id, content, ts, response_type)
+values ('UNIT_1', 1, 'all', '{"name":"Sam Sample","age":34}', 1597903000, 'the-response-type');
 
-insert into unit_data (unit_id, part_id, content, ts, response_type)
-values (2, 'all', '{"name":"Elias Example","age":35}', 1597903000, 'the-response-type');
+insert into unit_data (unit_name, test_id, part_id, content, ts, response_type)
+values ('UNIT.SAMPLE', 1, 'all', '{"name":"Elias Example","age":35}', 1597903000, 'the-response-type');
 
-insert into unit_data (unit_id, part_id, content, ts, response_type)
-values (2, 'other', '{"other":"stuff"}', 1597903000, 'the-response-type');
+insert into unit_data (unit_name, test_id, part_id, content, ts, response_type)
+values ('UNIT.SAMPLE', 1, 'other', '{"other":"stuff"}', 1597903000, 'the-response-type');
 
 
 insert into test_commands(id, test_id, keyword, parameter, commander_id, timestamp)

--- a/backend/test/unit/testdata.sql
+++ b/backend/test/unit/testdata.sql
@@ -21,6 +21,14 @@ values ('sample_user', 'pw_hash', 'run-hot-return', 1, '{"xxx":["BOOKLET.SAMPLE-
 insert into logins (name, password, mode, workspace_id, codes_to_booklets, source, valid_from, valid_to, valid_for, group_name, group_label, custom_texts)
 values ('future_user', 'pw_hash', 'run-hot-return', 1, '{}', 'testdata.sql', '2030-01-02 10:00:00', '2032-01-02 10:00:00', null, 'sample_group', 'Sample Group', '');
 
+
+insert into login_session_groups (group_label, group_name, token, workspace_id)
+values ('Sample Group', 'sample_group', 'group-token', 1);
+
+insert into login_session_groups (group_label, group_name, token, workspace_id)
+values ('Review Group', 'review_group', 'review-group-token', 1);
+
+
 insert into login_sessions (name, workspace_id, group_name, token)
 values ('test', 1, 'sample_group', 'nice_token');
 
@@ -43,13 +51,6 @@ insert into login_sessions (name, workspace_id, group_name, token)
 values ('test-review', 1, 'review_group', 'nice_token');
 
 
-insert into login_session_groups (group_label, group_name, token, workspace_id)
-values ('Sample Group', 'sample_group', 'group-token', 1);
-
-insert into login_session_groups (group_label, group_name, token, workspace_id)
-values ('Review Group', 'review_group', 'review-group-token', 1);
-
-
 insert into person_sessions(code, login_sessions_id, valid_until, token, name_suffix)
 values ('xxx', 4, '2030-01-02 10:00:00', 'person-token', 'xxx');
 
@@ -65,7 +66,7 @@ values ('', 5, '2032-01-02 10:00:00', 'person-of-future-login-token', '');
 insert into person_sessions(code, login_sessions_id, valid_until, token, name_suffix)
 values ('', 7, '2032-01-02 10:00:00', 'person-of-review-group-token', '');
 
-insert into tests (name, tests.file_id, person_id, laststate, locked, label, running, timestamp_server)
+insert into tests (name, file_id, person_id, laststate, locked, label, running, timestamp_server)
 values ('first sample test', 'first sample test', 1, '{"CURRENT_UNIT_ID":"UNIT_1"}', 0, 'first test label', 1, '2022-01-24 09:01:00');
 
 insert into tests (name, file_id, person_id, laststate, locked, label, running, timestamp_server)
@@ -74,14 +75,14 @@ values ('BOOKLET.SAMPLE-1', 'BOOKLET.SAMPLE-1',1, '', 0, 'second test label', 1,
 insert into tests (name, file_id, person_id, laststate, locked, label, running, timestamp_server)
 values ('BOOKLET.SAMPLE-1#bookletstate=isset', 'BOOKLET.SAMPLE-1', 5, null, 0, 'review test label', 1, '2022-01-24 09:01:00');
 
-insert into units (name, booklet_id, laststate)
-values ('UNIT_1', 1, '{"SOME_STATE":"WHATEVER"}');
+insert into units (name, booklet_id, laststate, original_unit_id)
+values ('UNIT_1', 1, '{"SOME_STATE":"WHATEVER"}', 'UNIT_1');
 
-insert into units (name, booklet_id, laststate)
-values ('UNIT.SAMPLE', 1, '{"PRESENTATIONCOMPLETE":"yes"}');
+insert into units (name, booklet_id, laststate, original_unit_id)
+values ('UNIT.SAMPLE', 1, '{"PRESENTATIONCOMPLETE":"yes"}', 'UNIT.SAMPLE');
 
-insert into units (name, booklet_id, laststate)
-values ('UNIT_1', 3, null);
+insert into units (name, booklet_id, laststate, original_unit_id)
+values ('UNIT_1', 3, null, 'UNIT_1');
 
 insert into unit_logs (unit_id, logentry, timestamp)
 values (2, 'sample unit log', '1597903000');

--- a/docker-compose.prod.tls.yml
+++ b/docker-compose.prod.tls.yml
@@ -69,7 +69,7 @@ services:
     image: ${DOCKERHUB_PROXY}iqbberlin/testcenter-backend:${VERSION}
 
   testcenter-db:
-    image: ${DOCKERHUB_PROXY}mysql:8.0
+    image: ${DOCKERHUB_PROXY}mysql:8.4
     command:
       - "--explicit-defaults-for-timestamp=TRUE"
       - "--sql-mode=PIPES_AS_CONCAT,ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION"

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -44,7 +44,7 @@ services:
     image: ${DOCKERHUB_PROXY}iqbberlin/testcenter-backend:${VERSION}
 
   testcenter-db:
-    image: ${DOCKERHUB_PROXY}mysql:8.0
+    image: ${DOCKERHUB_PROXY}mysql:8.4
     command:
       - "--explicit-defaults-for-timestamp=TRUE"
       - "--sql-mode=PIPES_AS_CONCAT,ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,7 +62,7 @@ services:
       - testcenter-cache-service
     environment:
       <<: *env-redis
-    volumes:
+    volumes_from:
       - testcenter-backend:ro
     networks:
       testcenter:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -121,7 +121,7 @@ services:
   testcenter-db:
     <<: *restart-policy
     container_name: testcenter-db
-    image: ${DOCKERHUB_PROXY}mysql:8.0
+    image: ${DOCKERHUB_PROXY}mysql:8.4
     environment:
       <<: *env-mysql
       MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,9 +5,23 @@ layout: default
 ### Breaking Changes
 * API Endpoints des Backends werden nicht mehr mit <HOSTNAME>/api aufgerufen, sondern mit <HOSTNAME>/api/; <HOSTNAME>/api gibt von nun an ein 404 error zurück
 
+### :warning: Hinweis für Administratoren
+* Das Update der Datenbankstruktur kann bei vielen vorhanden Daten *sehr* lange dauern. Es wird empfohlen, erst
+  sämtliche Studien zu beenden und die Daten zu löschen bevor geupdatet wird.
+
 ### Änderungen
 * Alle Container laufen ohne root-Rechte
 * Kubernetes: Backend, Frontend und File Server lassen sich nun bedingungslos skalieren über die values.yaml
+
+### Bugfix
+* Units konnten unter bestimmten Extrembedingungen doppelt angelegt werden, was zu doppelten Zeilen in den Ergebnisdaten
+  führte.
+* Beim Wegspeichern von Antworten und Unit-States wird der TimeStamp der Erhebung beachtet, nicht die Reihenfolge
+  in der die Daten beim Server ankommen. Dies konnte bei verzögertem Netzwerk u. U. zu geringfügigen Datenverlust
+  führen.
+
+### Sicherheit
+* Upgrade von MySQL 8.0 auf 8.4
 
 ## 16.2.0
 ### neue Features

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -109,6 +109,9 @@ layout: default
 ### Accessibility
 * Die Buttons im Starter-Menü sind nun mit der Tab Taste navigierbar
 
+### Sicherheit
+* Upgrade von MySQL 8.0 auf 8.4
+
 ## 16.0.0-alpha
 ### Kubernetes
 * Erste kubernetes-Deployment via Helm möglich. Im Github Release kann das Installationsskript `helm-install-tc.sh` genutzt werden, um die Helm Charts im Kubernetes-Cluster zu installieren.

--- a/docs/api/monitor.spec.yml
+++ b/docs/api/monitor.spec.yml
@@ -75,7 +75,8 @@ paths:
                 mode: run-hot-return
                 testId: 1
                 testState:
-                  "CURRENT_UNIT_ID": "1"
+                  "CURRENT_UNIT_ID": "UNIT.SAMPLE"
+                  "status": "running"
                 bookletName: BOOKLET.SAMPLE-1
                 unitName: UNIT.SAMPLE
                 unitState:
@@ -84,23 +85,14 @@ paths:
               - personId: 1
                 groupName: "sample_group"
                 personLabel: "test/xxx"
-                groupLabel: "Sample group"
+                groupLabel: "Primary Sample group"
                 mode: "run-hot-return"
                 testId: 2,
                 testState:
                   status: "locked"
-                bookletName: "BOOKLET.SAMPLE-2"
-                unitState: []
+                bookletName: "BOOKLET.SAMPLE-3"
+                unitState: {}
                 timestamp: 1606736826
-              - personId: 3
-                groupName: sample_group
-                personLabel: test-group-monitor
-                groupLabel: Sample group
-                mode: monitor-group
-                testId: -1
-                testState: []
-                unitState: []
-                timestamp: 1596455898
         "401":
           description: Not authenticated
         "410":
@@ -145,11 +137,12 @@ paths:
                 - personId: 1
                   groupName: sample_group
                   personLabel: test/xxx
-                  groupLabel: Sample group
+                  groupLabel: Primary Sample Group
                   mode: run-hot-return
                   testId: 1
                   testState:
-                    "CURRENT_UNIT_ID": "1"
+                    "CURRENT_UNIT_ID": "UNIT.SAMPLE"
+                    "status": "running"
                   bookletName: BOOKLET.SAMPLE-1
                   unitName: UNIT.SAMPLE
                   unitState:
@@ -158,23 +151,14 @@ paths:
                 - personId: 1
                   groupName: "sample_group"
                   personLabel: "test/xxx"
-                  groupLabel: "Sample group"
+                  groupLabel: Primary Sample Group
                   mode: "run-hot-return"
                   testId: 2,
                   testState:
                     status: "locked"
-                  bookletName: "BOOKLET.SAMPLE-2"
-                  unitState: []
+                  bookletName: "BOOKLET.SAMPLE-3"
+                  unitState: {}
                   timestamp: 1606736826
-                - personId: 3
-                  groupName: sample_group
-                  personLabel: test-group-monitor
-                  groupLabel: Sample group
-                  mode: monitor-group
-                  testId: -1
-                  testState: []
-                  unitState: []
-                  timestamp: 1596455898
         "401":
           description: Not authenticated
         "410":

--- a/docs/api/test.spec.yml
+++ b/docs/api/test.spec.yml
@@ -141,7 +141,7 @@ paths:
         - in: path
           name: unit_name
           description: unit-name (or alias) as defined in booklet
-          example: 1
+          example: UNIT.SAMPLE
           required: true
           schema:
             type: string
@@ -423,7 +423,7 @@ paths:
         - in: path
           name: unit_name
           description: unit-name (or alias) as defined in booklet
-          example: 1
+          example: UNIT.SAMPLE
           required: true
           schema:
             type: string

--- a/scripts/database/patches.d/15.0.0.sql
+++ b/scripts/database/patches.d/15.0.0.sql
@@ -42,8 +42,3 @@ group by
 
 alter table login_sessions
   add index login_sessions_groups_fk (workspace_id, group_name);
-
-alter table login_session_groups
-  add constraint login_sessions_fk
-    foreign key (workspace_id, group_name) references login_sessions (workspace_id, group_name)
-      on delete cascade;

--- a/scripts/database/patches.d/15.4.0.sql
+++ b/scripts/database/patches.d/15.4.0.sql
@@ -7,11 +7,3 @@ alter table tests
   modify name varchar(250) not null;
 
 update tests set file_id = name;
-alter table login_session_groups
-  drop foreign key login_sessions_fk;
-
-alter table login_session_groups
-  add constraint login_sessions_fk
-    foreign key (workspace_id, group_name) references login_sessions (workspace_id, group_name)
-      on update cascade on delete cascade;
-

--- a/scripts/database/patches.d/15.4.0.sql
+++ b/scripts/database/patches.d/15.4.0.sql
@@ -2,8 +2,7 @@ alter table file_relations
   modify relationship_type enum ('hasBooklet', 'containsUnit', 'usesPlayer', 'usesPlayerResource', 'isDefinedBy', 'usesScheme', 'unknown') not null;
 
 alter table tests
-  add file_id varchar(50) not null;
-alter table tests
+  add file_id varchar(50) not null,
   modify name varchar(250) not null;
 
 update tests set file_id = name;

--- a/scripts/database/patches.d/next.sql
+++ b/scripts/database/patches.d/next.sql
@@ -10,9 +10,9 @@ begin
       and CONSTRAINT_TYPE = 'FOREIGN KEY'
       and CONSTRAINT_NAME = 'login_sessions_fk'
   ) then
-    alter table login_session_groups
-      drop constraint login_sessions_fk;
-  end if;
+alter table login_session_groups
+drop constraint login_sessions_fk;
+end if;
 end;
 call clean_pre_mysql_8_4_key();
 drop procedure if exists clean_pre_mysql_8_4_key;
@@ -22,3 +22,101 @@ alter table login_sessions
   add constraint login_session_groups_fk
     foreign key (workspace_id, group_name) references login_session_groups (workspace_id, group_name)
       on update cascade on delete cascade;
+
+
+start transaction;
+
+alter table units
+  add column laststate_update_ts text after laststate;
+
+with duplicates as (
+  select u1.id
+  from units as u1
+       left join units as u2 on u1.name = u2.name and u1.booklet_id = u2.booklet_id
+  where u1.id > u2.id
+)
+update
+  units
+set
+  name = name || ' (duplicate id: ' || id || ')'
+where id in (select id from duplicates);
+
+alter table units
+  change booklet_id test_id bigint unsigned not null,
+  add constraint unique (test_id, name);
+
+-- unit_data
+alter table unit_data
+  collate = utf8mb3_german2_ci,
+  add unit_name varchar(50) not null after part_id,
+  add test_id bigint unsigned not null after unit_name;
+
+update unit_data
+  inner join units on unit_data.unit_id = units.id
+  set
+    unit_data.unit_name = units.name,
+    unit_data.test_id = units.test_id;
+
+alter table unit_data
+drop foreign key unit_data_units_id_fk,
+  drop primary key,
+  add primary key (part_id, test_id, unit_name),
+  add constraint unit_data_fk
+    foreign key (test_id, unit_name) references units (test_id, name)
+      on delete cascade,
+  drop column unit_id;
+
+
+
+-- reviews
+
+alter table unit_reviews
+  add unit_name varchar(50) not null first,
+  add test_id bigint unsigned not null after unit_name;
+
+update unit_reviews
+  left join units on unit_reviews.unit_id = units.id
+  set
+    unit_name = units.name,
+    unit_reviews.test_id = units.test_id;
+
+create index unit_reviews_unit_index
+  on unit_reviews (unit_name, test_id);
+
+alter table unit_reviews
+drop foreign key fk_review_unit;
+
+drop index index_fk_review_unit on unit_reviews;
+
+alter table unit_reviews
+drop column unit_id,
+  add constraint unit_reviews_fk
+    foreign key (test_id, unit_name) references units (test_id, name)
+      on delete cascade;
+
+
+-- logs
+alter table unit_logs
+  add unit_name varchar(50) not null first,
+  add test_id bigint unsigned not null after unit_name;
+
+update unit_logs
+  left join units on unit_logs.unit_id = units.id
+  set
+    unit_name = units.name,
+    unit_logs.test_id = units.test_id;
+
+alter table unit_logs
+drop foreign key fk_log_unit,
+  drop column unit_id,
+  add constraint unit_logs_fk
+    foreign key (test_id, unit_name) references units (test_id, name)
+      on delete cascade;
+
+-- units itself
+alter table units
+drop primary key,
+  add primary key (test_id, name),
+  drop column id;
+
+commit;

--- a/scripts/database/patches.d/next.sql
+++ b/scripts/database/patches.d/next.sql
@@ -21,7 +21,4 @@ drop procedure if exists clean_pre_mysql_8_4_key;
 alter table login_sessions
   add constraint login_session_groups_fk
     foreign key (workspace_id, group_name) references login_session_groups (workspace_id, group_name)
-      on delete cascade;
-
-
-
+      on update cascade on delete cascade;

--- a/scripts/database/patches.d/next.sql
+++ b/scripts/database/patches.d/next.sql
@@ -1,0 +1,27 @@
+-- the patch 15.0.0 contained a command, which does not work with MySQL > 8.4
+-- the following procedure would delete this deprecated kind fo key
+
+drop procedure if exists clean_pre_mysql_8_4_key;
+create procedure clean_pre_mysql_8_4_key()
+begin
+  if exists (
+    select * from INFORMATION_SCHEMA.TABLE_CONSTRAINTS
+    where TABLE_SCHEMA = database()
+      and CONSTRAINT_TYPE = 'FOREIGN KEY'
+      and CONSTRAINT_NAME = 'login_sessions_fk'
+  ) then
+    alter table login_session_groups
+      drop constraint login_sessions_fk;
+  end if;
+end;
+call clean_pre_mysql_8_4_key();
+drop procedure if exists clean_pre_mysql_8_4_key;
+
+
+alter table login_sessions
+  add constraint login_session_groups_fk
+    foreign key (workspace_id, group_name) references login_session_groups (workspace_id, group_name)
+      on delete cascade;
+
+
+

--- a/scripts/helm/testcenter/templates/file-server/configmap-nginx.yaml
+++ b/scripts/helm/testcenter/templates/file-server/configmap-nginx.yaml
@@ -45,6 +45,40 @@ data:
       source_charset utf-8;
       include mime.types;
       gzip on;
+      gzip_types # list from https://github.com/h5bp/server-configs-nginx/blob/main/h5bp/web_performance/compression.conf#L38
+        application/atom+xml
+        application/geo+json
+        application/javascript
+        application/x-javascript
+        application/json
+        application/ld+json
+        application/manifest+json
+        application/rdf+xml
+        application/rss+xml
+        application/vnd.ms-fontobject
+        application/wasm
+        application/x-web-app-manifest+json
+        application/xhtml+xml
+        application/xml
+        font/eot
+        font/otf
+        font/ttf
+        image/bmp
+        image/svg+xml
+        image/vnd.microsoft.icon
+        image/x-icon
+        text/cache-manifest
+        text/calendar
+        text/css
+        text/javascript
+        text/markdown
+        text/plain
+        text/xml
+        text/vcard
+        text/vnd.rim.location.xloc
+        text/vtt
+        text/x-component
+        text/x-cross-domain-policy;
 
       resolver kube-dns.kube-system.svc.cluster.local;
 
@@ -53,8 +87,8 @@ data:
       lua_package_path "/usr/share/nginx/auth/?.lua;;";
 
       map $http_testmode $root {
-        default /var/www/html;
-        integration /var/www/data-TEST;
+        default /var/www/testcenter/data;
+        integration /var/www/testcenter/data-TEST;
       }
 
       server {


### PR DESCRIPTION
Dieser PR enthält alle commits aus den ehemaligen branches `update/mysql` und `fix/duplicate-units` auf basis des aktuellen Masters (16.0.0).

Testzustand:
- system / e2e tests laufen alle (lokal, mit gui) durch
- dredd / API tests laufen alle durch
- backend unit tests laufen alle durch

- Manuell: `fix/duplicate-units` war bereits in der 16.0.0-beta und wurde auf diese weise bereits getestet. Dabei tauchten zwei bugs auf:
1) SQL-Fehler beim absenden eines unit-reviews. Der ist behoben
2) Einmal gab es beim test beenden einen SQL Fehler, dies konnte jedoch nicht rekonstruiert werden.

Ich würde den PR trotz seiner Komplexität als vergleichsweise sicher einstufen.

Problematisch weiterhin:  Das Update der Datenbankstruktur kann bei vielen vorhanden Daten *sehr* lange dauern.

fix #749 