### PR TITLE
explicitly set default sorting order in gm

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,10 @@
 ---
 layout: default
 ---
+## [next]
+### Verbesserungen
+* Testleiterkonsole ist beim ersten Aufruf immer nach der Spalte "Teilnehmer" 
+
 ## 16.0.0
 ### Kubernetes
 * Die Helm Chart für das Deployment des Testcenters hat die Version 1.0.0 erreicht und stellt damit eine erste stabile Version des Deployments auf Kubernetes dar.

--- a/frontend/src/app/group-monitor/group-monitor.component.html
+++ b/frontend/src/app/group-monitor/group-monitor.component.html
@@ -262,7 +262,7 @@
         </div>
 
         <div class="test-session-table-wrapper">
-          <table class="test-session-table" matSort (matSortChange)="setTableSorting($event)">
+          <table class="test-session-table" matSort matSortActive="personLabel" matSortDirection="asc" (matSortChange)="setTableSorting($event)">
             <thead>
               <tr class="mat-sort-container">
                 <td mat-sort-header="_checked" *ngIf="displayOptions.manualChecking">


### PR DESCRIPTION
- before the order was kind of random, mostly by name, but sometimes by activeState
- now always order by colum 'Teilnehmer'

resolves #876 