### PR TITLE
run timerclock as webworker

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,7 @@ layout: default
 ## [next]
 ### Verbesserungen
 * Testleiterkonsole ist beim ersten Aufruf immer nach der Spalte "Teilnehmer" 
+* Der ablaufende Timer wird nun mit einem Webworker im Browser umgesetzt. Sollte eine Testperson eine längere Zeit nicht den Fokus auf dem Testcenter-Tab haben, so läuft die Zeit nun unbeirrt weiter.
 
 ## 16.0.0
 ### Kubernetes


### PR DESCRIPTION
- rxjs.interval() is not reliable when the focus on the application is lost in the browser, which lead to slower running time or even automatic interval stop
- putting the interval logic inside a webworker lets the code live in own browser thread that doesnt get throttled automatically