### PR TITLE
Api Tests: Replace deprecated libraray request with node-fetch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "iqb-testcenter",
-  "version": "15.6.0",
+  "version": "16.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "iqb-testcenter",
-      "version": "15.6.0",
+      "version": "16.0.0",
       "license": "MIT",
       "devDependencies": {
         "@compodoc/compodoc": "^1.1.11",
@@ -26,6 +26,7 @@
         "kind-of": ">=6.0.3",
         "minimist": ">=0.2.1",
         "multi-part": "^3.0.0",
+        "node-fetch": "^2.7.0",
         "redis": "^4.6.11",
         "stream-to-string": "^1.2.0",
         "typescript": "~5.1.6",
@@ -10381,6 +10382,27 @@
       "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==",
       "dev": true
     },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/node-releases": {
       "version": "2.0.14",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.14.tgz",
@@ -13587,6 +13609,13 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/traverse": {
       "version": "0.6.8",
       "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.8.tgz",
@@ -14374,6 +14403,13 @@
         "defaults": "^1.0.3"
       }
     },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
     "node_modules/websocket-driver": {
       "version": "0.7.4",
       "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
@@ -14395,6 +14431,17 @@
       "dev": true,
       "engines": {
         "node": ">=0.8.0"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "kind-of": ">=6.0.3",
     "minimist": ">=0.2.1",
     "multi-part": "^3.0.0",
+    "node-fetch": "^2.7.0",
     "redis": "^4.6.11",
     "stream-to-string": "^1.2.0",
     "typescript": "~5.1.6",

--- a/test/api/test.js
+++ b/test/api/test.js
@@ -4,7 +4,7 @@ const Dredd = require('dredd');
 const gulp = require('gulp');
 const redis = require('redis');
 const YAML = require('yamljs');
-const request = require('request');
+const fetch = require('node-fetch');
 const cliPrint = require('../../scripts/helper/cli-print');
 const jsonTransform = require('../../scripts/helper/json-transformer');
 const testConfig = require('../config.json');
@@ -12,22 +12,32 @@ const { mergeSpecFiles, clearTmpDir } = require('../../scripts/update-specs');
 
 const tmpDir = fs.realpathSync(`${__dirname}'/../../tmp`);
 
-const getStatus = statusRequest => new Promise(resolve => {
+const getStatus = async statusRequest => {
   const startTime = Date.now();
-  request(statusRequest, (error, response, body) => {
-    if (error) {
-      console.log(`ConfirmTestConfig: The StatusRequest errored after ${Date.now() - startTime}ms`);
-      console.log('Requested status results in error: ', error);
-      console.log('Requested status: ', statusRequest);
-      console.log('Body of errored request: ', body);
-      resolve(error);
+  try {
+    const response = await fetch(statusRequest.url, {
+      headers: statusRequest.headers,
+      signal: AbortSignal.timeout(statusRequest.timeout)
+    });
+    if (!response.ok) {
+      console.log(`ConfirmTestConfig: The StatusRequest returned an error after ${Date.now() - startTime}ms`);
     } else {
       console.log(`ConfirmTestConfig: The StatusRequest got a response back after ${Date.now() - startTime}ms`);
-      resolve(response);
     }
+    return {
+      body: await response.text(),
+      statusCode: response.status
+    };
+  } catch (error) {
+    console.log(`ConfirmTestConfig: The StatusRequest errored after ${Date.now() - startTime}ms`);
+    console.log('Requested status results in error: ', error);
+    console.log('Requested status: ', statusRequest);
+    return {
+      body: error,
+      statusCode: -1
+    };
   }
-  );
-});
+};
 
 const sleep = ms => new Promise(resolve => {
   setTimeout(resolve, ms);
@@ -58,6 +68,7 @@ const confirmTestConfig = (serviceUrl, statusRequest) => (async done => {
       // eslint-disable-next-line no-await-in-loop
       await sleep(5000);
     } catch (e) {
+      // eslint-disable-next-line no-await-in-loop
       await sleep(5000);
     }
   }
@@ -153,13 +164,24 @@ const prepareSpecsForDredd = done => {
 const runDredd = serviceUrl => (async done => {
   cliPrint.headline(`Run API-test against ${serviceUrl}`);
   new Dredd({
-    endpoint: serviceUrl,
-    path: [`${tmpDir}/transformed.specs.*.yml`],
-    hookfiles: ['hooks.js'],
-    output: [`${tmpDir}/report.html`], // TODO do something with it
-    reporter: ['html'],
-    names: false, // use sth like this to restrict: only: ['specs > /workspace/{ws_id}/file > upload file > 403']
-    'inline-errors': true
+    endpoint: serviceUrl, // your URL to API endpoint the tests will run against
+    path: [`${tmpDir}/transformed.specs.*.yml`], // Required Array if Strings; filepaths to API description documents, can use glob wildcards
+    'dry-run': false, // Boolean, do not run any real HTTP transaction
+    names: false, // Boolean, Print Transaction names and finish, similar to dry-run
+    loglevel: 'debug', // String, logging level (debug, warning, error, silent)
+    only: [], // Array of Strings, run only transaction that match these names
+    header: [], // Array of Strings, these strings are then added as headers (key:value) to every transaction
+    user: null, // String, Basic Auth credentials in the form username:password
+    hookfiles: ['hooks.js'], // Array of Strings, filepaths to files containing hooks (can use glob wildcards)
+    reporter: ['html'], // Array of possible reporters, see folder lib/reporters
+    output: [`${tmpDir}/report.html`], // Array of Strings, filepaths to files used for output of file-based reporters
+    'inline-errors': true, // Boolean, If failures/errors are display immediately in Dredd run
+    require: null, // String, When using nodejs hooks, require the given module before executing hooks
+    'hooks-worker-after-connect-wait': '1000',
+    'hooks-worker-connect-timeout': '1500',
+    color: false
+    // emitter: new EventEmitter(), // listen to test progress, your own instance of EventEmitter
+    // apiDescriptions: ['FORMAT: 1A\n# Sample API\n']
   }).run((err, stats) => {
     console.log(stats);
     if (err) {
@@ -187,7 +209,7 @@ exports.runDreddTest = gulp.series(
       headers: {
         TestMode: 'prepare'
       },
-      timeout: 1000 * 60 * 5 // 5 minutes
+      timeout: 300000 // 5 minutes
     }
   ),
   clearTmpDir,
@@ -201,7 +223,7 @@ exports.runDreddTestFs = gulp.series(
     testConfig.file_service_url,
     {
       url: `${testConfig.file_service_url}/health`,
-      timeout: 1000 * 60 * 5 // 5 minutes
+      timeout: 300000 // 5 minutes
     }
   ),
   clearTmpDir,


### PR DESCRIPTION
Dies könnte wahrscheinlich das Fehlschlagen des ersten Testcalls der Api-Tests auf den CI-workern lösen.

- Aber! Es gibt beim Einrichten einen Backenfehler, der Master scheint korrupt zu sein?

PR geöffnet um das zu testen.
