### PR TITLE
fix gm that shows testsessions from wrong group

### DIFF
--- a/broadcasting-service/src/test-session/test-session.service.ts
+++ b/broadcasting-service/src/test-session/test-session.service.ts
@@ -115,7 +115,8 @@ export class TestSessionService {
     return Object.values(this.testSessions)
       .reduce(
         // eslint-disable-next-line max-len
-        (allTestSessions: TestSessionChange[], groupTestSessions: { [g: string]: TestSessionChange }): TestSessionChange[] => allTestSessions.concat(Object.values(groupTestSessions)), []
+        (allTestSessions: TestSessionChange[], groupTestSessions: { [g: string]: TestSessionChange }): TestSessionChange[] => allTestSessions.concat(Object.values(groupTestSessions)),
+        []
       );
   }
 

--- a/broadcasting-service/src/testee/testee.service.ts
+++ b/broadcasting-service/src/testee/testee.service.ts
@@ -8,7 +8,7 @@ import { Command } from '../command/command.interface';
 export class TesteeService {
   constructor(
     private readonly websocketGateway: WebsocketGateway,
-    private readonly http: HttpService,
+    private readonly http: HttpService
   ) {
     this.websocketGateway.getDisconnectionObservable().subscribe((disconnected: string) => {
       this.notifyDisconnection(disconnected);


### PR DESCRIPTION
- a not unsubscribed subscription in the handling of the group monitor websocket testdata lead to the fact that once a group monitor was opened, the subscription would push every _clock$ interval the same state to the application. When one opened two group monitors within the same application (without refreshing in between), two concurrent leaking subscriptions would push their state to the application