### PR TITLE
clean up the wsSubject$ when error emits

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,9 +3,10 @@ layout: default
 ---
 ## [next]
 ### Verbesserungen
-* Testleiterkonsole ist beim ersten Aufruf immer nach der Spalte "Teilnehmer" 
+* Testleiterkonsole ist beim ersten Aufruf immer nach der Spalte "Teilnehmer".
 * Der ablaufende Timer wird nun mit einem Webworker im Browser umgesetzt. Sollte eine Testperson eine längere Zeit nicht den Fokus auf dem Testcenter-Tab haben, so läuft die Zeit nun unbeirrt weiter.
-* Adminbereich: Die Gruppen im Tab "Ergebniss/Antworten" zeigen die einzigartige ID als Tooltip an, hilfreich wenn es das selbe Label mehrmals gibt
+* Adminbereich: Die Gruppen im Tab "Ergebniss/Antworten" zeigen die einzigartige ID als Tooltip an, hilfreich wenn es das selbe Label mehrmals gibt.
+* Die Websocket Verbindung funktioniert nun auch weiterhin, nachdem der Broadcasting-Service neu gestartet wird.
 
 ## 16.0.0
 ### Kubernetes

--- a/frontend/src/app/shared/services/websocket-backend/websocket-backend.service.ts
+++ b/frontend/src/app/shared/services/websocket-backend/websocket-backend.service.ts
@@ -37,12 +37,12 @@ export abstract class WebsocketBackendService<T> extends WebsocketService implem
   protected observeEndpointAndChannel(): Observable<T> {
     if (!this.data$) {
       this.data$ = new BehaviorSubject<T>(this.initialData);
-      this.pollNext();
+      this.pollEndpointAndSubscribeWs();
     }
     return this.data$;
   }
 
-  private pollNext(): void {
+  private pollEndpointAndSubscribeWs(): void {
     this.connectionClosed = false;
 
     this.unsubscribeFromWebsocket();
@@ -71,7 +71,7 @@ export abstract class WebsocketBackendService<T> extends WebsocketService implem
 
   cutConnection(): void {
     this.unsubscribeFromWebsocket();
-    this.closeConnection();
+    this.completeConnection();
 
     if (this.pollingTimeoutId) {
       clearTimeout(this.pollingTimeoutId);
@@ -88,7 +88,9 @@ export abstract class WebsocketBackendService<T> extends WebsocketService implem
 
     this.pollingTimeoutId = window.setTimeout(
       () => {
-        if (!this.connectionClosed) { this.pollNext(); }
+        if (!this.connectionClosed) {
+          this.pollEndpointAndSubscribeWs();
+        }
       },
       this.pollingInterval
     );

--- a/frontend/src/app/shared/services/websocket/websocket.service.spec.ts
+++ b/frontend/src/app/shared/services/websocket/websocket.service.spec.ts
@@ -20,7 +20,7 @@ describe('WebsocketService', () => {
     // TODO implement unit.test
   });
 
-  xit('closeConnection() should close connection', () => {
+  xit('completeConnection() should close connection', () => {
     // TODO implement unit.test
   });
 

--- a/frontend/src/app/shared/services/websocket/websocket.service.ts
+++ b/frontend/src/app/shared/services/websocket/websocket.service.ts
@@ -41,22 +41,33 @@ export class WebsocketService {
           next: () => {
           },
           error: () => {
-            this.wsConnected$.next('disconnected');
+            this.errorConnection();
           },
           complete: () => {
-            this.closeConnection();
+            this.completeConnection();
           }
         });
     }
   }
 
-  protected closeConnection(): void {
+  protected completeConnection(): void {
     this.wsConnected$.next('disconnected');
     if (this.wsSubscription) {
       this.wsSubscription.unsubscribe();
     }
     if (this.wsSubject$) {
       this.wsSubject$.complete();
+      this.wsSubject$ = null;
+    }
+  }
+
+  protected errorConnection(): void {
+    this.wsConnected$.next('disconnected');
+    if (this.wsSubscription) {
+      this.wsSubscription.unsubscribe();
+    }
+    if (this.wsSubject$) {
+      this.wsSubject$.error('An error occured. The websocket connection will be closed.');
       this.wsSubject$ = null;
     }
   }

--- a/frontend/src/app/test-controller/services/command.service.ts
+++ b/frontend/src/app/test-controller/services/command.service.ts
@@ -50,9 +50,8 @@ export class CommandService extends WebsocketBackendService<Command[]> implement
 
     this.setUpGlobalCommandsForDebug();
 
-    // as services don't have a OnInit Hook (see: https://v9.angular.io/api/core/OnInit) we subscribe here
-    this.subscribeReceivedCommands();
-    this.subscribeTestStarted();
+    this.commandSubscription = this.subscribeReceivedCommands();
+    this.testStartedSubscription = this.subscribeTestStarted();
   }
 
   static commandToString(command: Command): string {
@@ -81,8 +80,8 @@ export class CommandService extends WebsocketBackendService<Command[]> implement
     }
   }
 
-  private subscribeReceivedCommands() {
-    this.commandSubscription = this.commandReceived$
+  private subscribeReceivedCommands(): Subscription {
+    return this.commandReceived$
       .pipe(
         filter((command: Command) => (this.executedCommandIds.indexOf(command.id) < 0)),
         // min delay between items
@@ -97,12 +96,12 @@ export class CommandService extends WebsocketBackendService<Command[]> implement
       ).subscribe(command => this.command$.next(command));
   }
 
-  private subscribeTestStarted() {
+  private subscribeTestStarted(): Subscription {
     if (typeof this.testStartedSubscription !== 'undefined') {
       this.testStartedSubscription?.unsubscribe();
     }
 
-    this.testStartedSubscription = this.tcs.state$
+    return this.tcs.state$
       .pipe(
         distinctUntilChanged(),
         map(CommandService.testStartedOrStopped),


### PR DESCRIPTION
- before: the subject was not cleaned up before an error was emitted (eg. when the bs-service died). When the websocket was reopened with the scheduleNextPoll(), the called getChannel() did not call the connect() function anew, but returned the existing wsSubject$, which is a reference to a not existing websocket
- Now the wsSubject is cleaned up properly and rebuild every time a new connction is opened. I reused the closeConnection() for the new errorConnection() to keep the practice to close the subscription as well - only calling `this.wsSubject$ = null` could have been enough

resolves z #510 