### PR TITLE
[GM]: BlockId now shows with an appropriate label

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,7 @@ layout: default
 * Testleiterkonsole ist beim ersten Aufruf immer nach der Spalte "Teilnehmer" 
 * Der ablaufende Timer wird nun mit einem Webworker im Browser umgesetzt. Sollte eine Testperson eine längere Zeit nicht den Fokus auf dem Testcenter-Tab haben, so läuft die Zeit nun unbeirrt weiter.
 * Adminbereich: Die Gruppen im Tab "Ergebniss/Antworten" zeigen die einzigartige ID als Tooltip an, hilfreich wenn es das selbe Label mehrmals gibt
+* Testleiterkonsole: Das Blocklabel zeigt nun die BlockId mit 'Block 1' an, statt nur '1' (wenn kein Label für den Block gesetzt wurde)
 
 ## 16.0.0
 ### Kubernetes

--- a/frontend/src/app/group-monitor/test-session/test-session.component.css
+++ b/frontend/src/app/group-monitor/test-session/test-session.component.css
@@ -215,6 +215,10 @@ h2 {
   font-weight: bold
 }
 
+.unit-badge {
+  margin-left: 0.2em;
+}
+
 .unit-badge.danger {
   color: #821123;
 }

--- a/frontend/src/app/group-monitor/test-session/test-session.component.html
+++ b/frontend/src/app/group-monitor/test-session/test-session.component.html
@@ -45,7 +45,11 @@
 
 <td class="block" (contextmenu)="deselectForce($event)" *ngIf="displayOptions.blockColumn === 'show'">
   <div *ngIf="testSession.current as current;" class="vertical-align-middle">
-    {{current.parent.label || current.parent.blockId || current.parent.id}}
+    {{
+      current.parent.label ||
+      (current.parent.blockId ? ('Block' | customtext:'gm_col_blockLabel' | async)! + ' ' + current.parent.blockId : '') ||
+      current.parent.id
+    }}
     <mat-icon
       class="unit-badge"
       *ngIf="testSession | timeleft : current.parent as timeLeft"


### PR DESCRIPTION
- before only the id was shown, resulting in labels like '1'