### PR TITLE
add customtexts in group-monitor view

### DIFF
--- a/definitions/custom-texts.json
+++ b/definitions/custom-texts.json
@@ -191,6 +191,14 @@
     "label" : "Überschrift: Gruppenmonitor",
     "defaultvalue" : "Gruppenüberwachung"
   },
+  "gm_show_monitor" : {
+    "label" : "Titel für Monitorfunktion",
+    "defaultvalue" : "Testgruppen-Überwachung"
+  },
+  "gm_show_test" : {
+    "label" : "Titel für Testüberprüfung",
+    "defaultvalue" : "Folgende Testhefte stehen für Sie zur Ansicht bereit:"
+  },
   "gm_menu_filter" : {
     "label" : "Meinueintrag: Sitzungen ausblenden",
     "defaultvalue" : "Sitzungen ausblenden"

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,11 @@ layout: default
 * Werden in der Testtakers.xml die Werte für `validTo` geändert, dann wird dies nun sowohl auf der Login-Ebene, als auch auf der individuellen Session-Ebene angewandt. Es verhält sich nun wie erwartet.
 * Die Häufigkeit mit der fälschlicherweise die gleichen Tests (Booklets) mehrmals pro Person angezeigt werden, ist minimiert worden.
 
+## Custom Texts
+* neue Felder
+  * `gm_show_monitor` -> Titel für Monitorfunktion
+  * `gm_show_test` -> Titel für Testüberprüfung
+
 ## 16.0.2
 ### Bugfixes
 * Testleitungskonsole: Dialog für das Festlegene einer neuen Restzeit für einen zeitgesteuerten Block erlaubt jetzt die manuelle Eingabe, damit die Funktion auf allen Geräten genutzt werden kann. Eine nicht valide Zahl (kleiner als 0, größer als Maximalzeit, keine Zahl) resultiert in keinem Sprung.

--- a/docs/pages/custom-texts.md
+++ b/docs/pages/custom-texts.md
@@ -139,6 +139,8 @@ Funktioniert auch nicht? Dann...
 |gm_selection_text_expired|Der Text im Button bei Auswahl der Testleitungskonsole, wenn die Gruppe abgelaufen ist. $date wird gegen das Ablaufdatum ersetzt.|Gruppe abgelaufen seit %date.|
 |gm_selection_text_scheduled|Der Text im Button bei Auswahl der Testleitungskonsole, wenn die noch nicht freigegeben abgelaufen ist. $date wird gegen das Freigabedatum ersetzt.|Gruppe erst freigegeben ab %date.|
 |gm_settings_tooltip|Control: Ansicht|Ansicht|
+|gm_show_monitor|Titel für Monitorfunktion|Testgruppen-Überwachung|
+|gm_show_test|Titel für Testüberprüfung|Folgende Testhefte stehen für Sie zur Ansicht bereit:|
 |gm_timeleft_tooltip|Tooltip zeitgesteuerter Block: verbleibende Zeit. Ersetzungen (%s): Verbleibende Minuten, Minuten gesamt|Verbleibende Zeit: %s von %s Minute(n)|
 |gm_timemax_tooltip|Tooltip zeitgesteuerter Block: Noch nicht gestartet. Ersetzung (%s): Minutenzahl, |Zeitgesteuerter Block: %s Minute(n)|
 |gm_timeup_tooltip|Tooltip zeitgesteuerter Block: Zeit abgelaufen|Zeit abgelaufen|

--- a/frontend/src/app/app-root/starter/starter.component.html
+++ b/frontend/src/app/app-root/starter/starter.component.html
@@ -38,7 +38,7 @@
         </button>
 
 
-        <h4 *ngIf="accessObjects.testGroupMonitor">Test-Gruppen Überwachung</h4>
+        <h4 *ngIf="accessObjects.testGroupMonitor">{{ 'Testgruppen-Überwachung' | customtext: 'gm_subheadline' | async }}</h4>
         <button
           *ngFor="let accessObject of accessObjects.testGroupMonitor let i = index"
           mat-raised-button color="primary"
@@ -78,7 +78,7 @@
         </button>
 
         <h4 *ngIf="accessObjects.testGroupMonitor && accessObjects.test">
-          Folgende Testhefte stehen für Sie zur Ansicht bereit:
+          {{ 'Folgende Testhefte stehen für Sie zur Ansicht bereit:' | customtext : 'gm_show_test' | async }}
         </h4>
         <button
           *ngFor="let b of accessObjects.test"


### PR DESCRIPTION
resolves #928 

* neue Felder
  * `gm_show_monitor` -> Titel für Monitorfunktion -> 'Testgruppen-Überwachung'
  * `gm_show_test` -> Titel für Testüberprüfung -> 'Folgende Testhefte stehen für Sie zur Ansicht bereit:'
