### PR TITLE
make forceTimeRestrictions overide time settings

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,7 @@ layout: default
 * Werden in der Testtakers.xml die Werte für `validTo` geändert, dann wird dies nun sowohl auf der Login-Ebene, als auch auf der individuellen Session-Ebene angewandt. Es verhält sich nun wie erwartet.
 * Die Häufigkeit mit der fälschlicherweise die gleichen Tests (Booklets) mehrmals pro Person angezeigt werden, ist minimiert worden.
 * Auf der Starterseite wird nun immer der Text des customtext `login_subtitle` angezeigt. Vorher wurde immer der Subtitle der vorher besuchten Seite angezeigt.
+* Modi mit dem Wert `forceTimeRestrictions=false` (RUN-DEMO, MONITOR-GROUP, MONITOR-STUDY, RUN-REVIEW, RUN-TRIAL, SYS-CHECK-LOGIN), sind nun korrekterweise nicht von Zeitbeschränkten Blöck in ihrer Navigation eingeschränkt.
 
 ## Custom Texts
 * neue Felder

--- a/frontend/src/app/test-controller/services/test-controller.service.ts
+++ b/frontend/src/app/test-controller/services/test-controller.service.ts
@@ -884,13 +884,13 @@ export class TestControllerService {
     ) {
       return of(true);
     }
-    if (this.testlets[this.currentTimerId].restrictions.timeMax?.leave === 'forbidden') {
-      this.ms.show('Es darf erst weiter geblättert werden, wenn die Zeit abgelaufen ist.');
-      return of(false);
-    }
     if (!this.testMode.forceTimeRestrictions) {
       this.interruptTimer();
       return of(true);
+    }
+    if (this.testlets[this.currentTimerId].restrictions.timeMax?.leave === 'forbidden') {
+      this.ms.show('Es darf erst weiter geblättert werden, wenn die Zeit abgelaufen ist.');
+      return of(false);
     }
 
     const dialogCDRef = this.confirmDialog.open(ConfirmDialogComponent, {


### PR DESCRIPTION
resolves #932 

- before the order of checks for time restrictions made forceTimeRestrictions to no be respected
- now forceTimeRestrictions overrules every other time restriction rule, allowing the unhindered navigation disregarding time