### PR TITLE
Akkordion gm tests

### DIFF
--- a/definitions/custom-texts.json
+++ b/definitions/custom-texts.json
@@ -201,7 +201,7 @@
   },
   "gm_show_test" : {
     "label" : "Titel für Testüberprüfung",
-    "defaultvalue" : "Folgende Testhefte stehen für Sie zur Ansicht bereit:"
+    "defaultvalue" : "Testhefte anzeigen"
   },
   "gm_menu_filter" : {
     "label" : "Meinueintrag: Sitzungen ausblenden",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,9 @@
 layout: default
 ---
 ## [next]
+### Verbesserung
+* Testleitungskonsole: Die Testhefte werden sind nun in einem Akkordion-Element positioniert und können nach einem extra Klick angezeigt werden. Das räumt visuell das Starter-Menü auf und rückt den Fokus auf die eigentliche Funktionalität der Testleitungkonsole zurück.
+
 ### Bugfix
 * Werden in der Testtakers.xml die Werte für `validTo` geändert, dann wird dies nun sowohl auf der Login-Ebene, als auch auf der individuellen Session-Ebene angewandt. Es verhält sich nun wie erwartet.
 * Die Häufigkeit mit der fälschlicherweise die gleichen Tests (Booklets) mehrmals pro Person angezeigt werden, ist minimiert worden.

--- a/docs/pages/custom-texts.md
+++ b/docs/pages/custom-texts.md
@@ -140,7 +140,7 @@ Funktioniert auch nicht? Dann...
 |gm_selection_text_scheduled|Der Text im Button bei Auswahl der Testleitungskonsole, wenn die noch nicht freigegeben abgelaufen ist. $date wird gegen das Freigabedatum ersetzt.|Gruppe erst freigegeben ab %date.|
 |gm_settings_tooltip|Control: Ansicht|Ansicht|
 |gm_show_monitor|Titel für Monitorfunktion|Testgruppen-Überwachung|
-|gm_show_test|Titel für Testüberprüfung|Folgende Testhefte stehen für Sie zur Ansicht bereit:|
+|gm_show_test|Titel für Testüberprüfung|Testhefte anzeigen|
 |gm_timeleft_tooltip|Tooltip zeitgesteuerter Block: verbleibende Zeit. Ersetzungen (%s): Verbleibende Minuten, Minuten gesamt|Verbleibende Zeit: %s von %s Minute(n)|
 |gm_timemax_tooltip|Tooltip zeitgesteuerter Block: Noch nicht gestartet. Ersetzung (%s): Minutenzahl, |Zeitgesteuerter Block: %s Minute(n)|
 |gm_timeup_tooltip|Tooltip zeitgesteuerter Block: Zeit abgelaufen|Zeit abgelaufen|
@@ -153,6 +153,7 @@ Funktioniert auch nicht? Dann...
 |login_codeInputPrompt|Aufforderung, Code einzugeben (bei einem zweistufigen Login-Prozess)|Bitte Log-in eingeben, der auf dem Zettel steht!|
 |login_codeInputTitle|Titel des Eingabeformulares für den Code|Log-in eingeben|
 |login_pagesNaviPrompt|Aufforderungstext, weitere Seiten einer Unit auszuwählen, z. B. 'Wähle hier andere Seiten dieser Aufgabe:'|Weitere Seiten:|
+|login_subtitle|Titel für Starter-Seite|Testauswahl|
 |login_testEndButtonLabel|Schalterbeschriftung für 'Test beenden'|Test beenden|
 |login_testResumeButtonLabel|Schalterbeschriftung für 'Test fortsetzen'|Test fortsetzen|
 |login_unsupportedBrowser|Warnung auf de Startseite, wenn nicht unterstützer Browser verwendet wird. Ersetzungen (%s): Browser-Name, Browser-Version.|Ihr Browser <strong>%s %s</strong> wird von dieser Anwendung leider nicht offiziell unterstützt. Dies kann möglicherweise zu Fehlfunktionen führen! <br> Bitte verwenden Sie eine aktuelle Version von <a href='https://www.getfirefox.org' target='_blank'>Mozilla Firefox</a>, <a href='https://www.google.com/chrome/' target='_blank'>Google Chrome</a>, <a href='https://www.microsoft.com/en-us/edge/download' target='_blank'>Microsoft Edge</a> oder <a href='https://support.apple.com/downloads/safari' target='_blank'>Apple Safari.</a>|

--- a/frontend/src/app/app-root/starter/starter.component.css
+++ b/frontend/src/app/app-root/starter/starter.component.css
@@ -28,3 +28,21 @@ div.starter-status {
 h4 {
   margin-bottom: 0.2em;
 }
+
+mat-accordion {
+  margin-top: 20px;
+  margin-bottom: 10px;
+}
+
+mat-expansion-panel:not([class*="mat-elevation-z"]) {
+  box-shadow: none;
+}
+
+mat-expansion-panel-header {
+  padding-left: 0;
+}
+
+mat-panel-title {
+  font-size: initial;
+  font-weight: 700;
+}

--- a/frontend/src/app/app-root/starter/starter.component.html
+++ b/frontend/src/app/app-root/starter/starter.component.html
@@ -77,7 +77,7 @@
           <div class="starter-status">Anhänge Verwalten</div>
         </button>
 
-        <ng-container *ngIf="!accessObjects.testGroupMonitor && accessObjects.test; else gmTemplate">
+        <ng-container *ngIf="!accessObjects.testGroupMonitor && accessObjects.test">
           <button
             *ngFor="let b of accessObjects.test"
              mat-raised-button color="primary"
@@ -92,24 +92,31 @@
             </div>
           </button>
         </ng-container>
-        <ng-template #gmTemplate>
-          <h4 *ngIf="accessObjects.testGroupMonitor && accessObjects.test">
-            {{ 'Folgende Testhefte stehen für Sie zur Ansicht bereit:' | customtext : 'gm_show_test' | async }}
-          </h4>
-          <button
-            *ngFor="let b of accessObjects.test"
-            mat-raised-button color="primary"
-            class="starter"
-            [disabled]="!!b.flags.locked"
-            [attr.aria-label]="'Starte Testheft ' + b.label"
-            [attr.data-cy]="'booklet-' + b.id"
-            (click)="startTest(b)">
-            <div class="starter-title">{{b.label}}</div>
-            <div class="starter-status">
-              {{b.flags.locked ? 'gesperrt' : (b.flags.running ? 'Fortsetzen' : (accessObjects.testGroupMonitor ? 'Ansehen' : 'Starten'))}}
-            </div>
-          </button>
-        </ng-template>
+
+        <ng-container *ngIf="accessObjects.testGroupMonitor && accessObjects.test">
+          <mat-accordion displayMode="default">
+            <mat-expansion-panel>
+              <mat-expansion-panel-header [collapsedHeight]="'auto'" [expandedHeight]="'auto'">
+                <mat-panel-title>
+                  {{ 'Testhefte anzeigen' | customtext : 'gm_show_test' | async }}
+                </mat-panel-title>
+              </mat-expansion-panel-header>
+              <button
+                *ngFor="let b of accessObjects.test"
+                mat-raised-button color="primary"
+                class="starter"
+                [disabled]="!!b.flags.locked"
+                [attr.aria-label]="'Starte Testheft ' + b.label"
+                [attr.data-cy]="'booklet-' + b.id"
+                (click)="startTest(b)">
+                <div class="starter-title">{{b.label}}</div>
+                <div class="starter-status">
+                  {{b.flags.locked ? 'gesperrt' : (b.flags.running ? 'Fortsetzen' : (accessObjects.testGroupMonitor ? 'Ansehen' : 'Starten'))}}
+                </div>
+              </button>
+            </mat-expansion-panel>
+          </mat-accordion>
+        </ng-container>
 
         <ng-container *ngIf="accessObjects.sysCheck">
           <h4>System-Check</h4>
@@ -125,6 +132,7 @@
             <div class="starter-status">{{sc.description}}</div>          </button>
         </ng-container>
       </div>
+
       <tc-alert
         *ngIf="(accessObjects.test && !accessObjects.test.length) || !(accessObjects | keyvalue).length"
         level="info"
@@ -132,6 +140,7 @@
         text="Für diese Anmeldung wurde kein Test gefunden."
       ></tc-alert>
     </mat-card-content>
+
     <mat-card-actions [style.justify-content]="'space-between'">
       <button *ngIf="isSuperAdmin" mat-raised-button color="primary" [routerLink]="['/superadmin']" data-cy='goto-superadmin-settings'>
         Systemverwaltung

--- a/frontend/src/app/app-root/starter/starter.component.html
+++ b/frontend/src/app/app-root/starter/starter.component.html
@@ -77,22 +77,39 @@
           <div class="starter-status">Anhänge Verwalten</div>
         </button>
 
-        <h4 *ngIf="accessObjects.testGroupMonitor && accessObjects.test">
-          {{ 'Folgende Testhefte stehen für Sie zur Ansicht bereit:' | customtext : 'gm_show_test' | async }}
-        </h4>
-        <button
-          *ngFor="let b of accessObjects.test"
-           mat-raised-button color="primary"
-           class="starter"
-           [disabled]="!!b.flags.locked"
-           [attr.aria-label]="'Starte Testheft ' + b.label"
-           [attr.data-cy]="'booklet-' + b.id"
-           (click)="startTest(b)">
-          <div class="starter-title">{{b.label}}</div>
-          <div class="starter-status">
-            {{b.flags.locked ? 'gesperrt' : (b.flags.running ? 'Fortsetzen' : (accessObjects.testGroupMonitor ? 'Ansehen' : 'Starten'))}}
-          </div>
-        </button>
+        <ng-container *ngIf="!accessObjects.testGroupMonitor && accessObjects.test; else gmTemplate">
+          <button
+            *ngFor="let b of accessObjects.test"
+             mat-raised-button color="primary"
+             class="starter"
+             [disabled]="!!b.flags.locked"
+             [attr.aria-label]="'Starte Testheft ' + b.label"
+             [attr.data-cy]="'booklet-' + b.id"
+             (click)="startTest(b)">
+            <div class="starter-title">{{b.label}}</div>
+            <div class="starter-status">
+              {{b.flags.locked ? 'gesperrt' : (b.flags.running ? 'Fortsetzen' : (accessObjects.testGroupMonitor ? 'Ansehen' : 'Starten'))}}
+            </div>
+          </button>
+        </ng-container>
+        <ng-template #gmTemplate>
+          <h4 *ngIf="accessObjects.testGroupMonitor && accessObjects.test">
+            {{ 'Folgende Testhefte stehen für Sie zur Ansicht bereit:' | customtext : 'gm_show_test' | async }}
+          </h4>
+          <button
+            *ngFor="let b of accessObjects.test"
+            mat-raised-button color="primary"
+            class="starter"
+            [disabled]="!!b.flags.locked"
+            [attr.aria-label]="'Starte Testheft ' + b.label"
+            [attr.data-cy]="'booklet-' + b.id"
+            (click)="startTest(b)">
+            <div class="starter-title">{{b.label}}</div>
+            <div class="starter-status">
+              {{b.flags.locked ? 'gesperrt' : (b.flags.running ? 'Fortsetzen' : (accessObjects.testGroupMonitor ? 'Ansehen' : 'Starten'))}}
+            </div>
+          </button>
+        </ng-template>
 
         <ng-container *ngIf="accessObjects.sysCheck">
           <h4>System-Check</h4>

--- a/frontend/src/app/app-root/starter/starter.component.ts
+++ b/frontend/src/app/app-root/starter/starter.component.ts
@@ -13,6 +13,7 @@ import { SysCheckDataService } from '../../sys-check/sys-check-data.service';
 import { MatDialog } from '@angular/material/dialog';
 
 @Component({
+  selector: 'tc-starter',
   templateUrl: './starter.component.html',
   styleUrls: ['./starter.component.css']
 })

--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -39,6 +39,8 @@ import { AppErrorHandler } from './app.error-handler';
 import { ErrorInterceptor } from './error.interceptor';
 import { StarterComponent } from './app-root/starter/starter.component';
 import { TestModeInterceptor } from './test-mode.interceptor';
+import { CdkAccordionModule } from '@angular/cdk/accordion';
+import { MatExpansionModule } from '@angular/material/expansion';
 
 @NgModule({
   declarations: [
@@ -74,7 +76,9 @@ import { TestModeInterceptor } from './test-mode.interceptor';
     HttpClientModule,
     RouterModule,
     AppRoutingModule,
-    SharedModule
+    SharedModule,
+    CdkAccordionModule,
+    MatExpansionModule
   ],
   providers: [
     BackendService,

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -139,3 +139,18 @@ div.logo img {
   font-size: larger;
   font-weight: bold;
 }
+
+/* */
+/* Styles that must bridge encapsulation across multiple component-levels, thus cannot be defined within themselves */
+/* */
+
+tc-starter {
+  .mat-expansion-panel-body {
+    padding-left: 0 !important;
+
+    .starter {
+      margin-top: 10px;
+      width: 100%;
+    }
+  }
+}


### PR DESCRIPTION
resolves #933 

* Testleitungskonsole: Die Testhefte werden sind nun in einem Akkordion-Element positioniert und können nach einem extra Klick angezeigt werden. Das räumt visuell das Starter-Menü auf und rückt den Fokus auf die eigentliche Funktionalität der Testleitungkonsole zurück.
