### PR TITLE
Reload button

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ composer-refresh-autoload:
 	$(MAKE) -f $(MK_FILE_DIR)/dev.mk -C $(MK_FILE_DIR) $@
 re-init-backend:
 	$(MAKE) -f $(MK_FILE_DIR)/dev.mk -C $(MK_FILE_DIR) $@
+
 create-interfaces:
 	$(MAKE) -f $(MK_FILE_DIR)/dev.mk -C $(MK_FILE_DIR) $@
 update-docs:

--- a/backend/src/controller/SystemController.class.php
+++ b/backend/src/controller/SystemController.class.php
@@ -171,7 +171,11 @@ class SystemController extends Controller {
   }
 
   public static function postClearCache(Request $request, Response $response): Response {
+    $directives = JSON::decode($request->getBody()->getContents())->directives;
     return $response
-      ->withHeader('Clear-Site-Data', '"*"');
+      ->withHeader('Clear-Site-Data',
+        !empty($directives) ?
+          implode(',', $directives) :
+          '"*"');
   }
 }

--- a/common/src/classes/booklet-config-data.class.ts
+++ b/common/src/classes/booklet-config-data.class.ts
@@ -19,6 +19,7 @@ export class BookletConfigData {
   lock_test_on_termination: 'ON' | 'OFF' = 'OFF';
   ask_for_fullscreen: 'ON' | 'OFF' = 'OFF';
   show_fullscreen_button: 'ON' | 'OFF' = 'OFF';
+  show_reload_button: 'ON' | 'OFF' = 'OFF';
   unit_responses_buffer_time: string = '5000';
   unit_state_buffer_time: string = '6000';
   test_state_buffer_time: string = '1000';

--- a/definitions/booklet-config.json
+++ b/definitions/booklet-config.json
@@ -159,6 +159,14 @@
     },
     "defaultvalue": "OFF"
   },
+  "show_reload_button": {
+    "label": "Soll ein Knopf für 'Seite neu laden' in der Titelleiste angezeigt werden?",
+    "options": {
+      "ON": "Ja.",
+      "OFF": "Nein."
+    },
+    "defaultvalue": "OFF"
+  },
   "unit_responses_buffer_time": {
     "label": "Speicherfrequenz für Antworten in Ms.",
     "options": {},

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,11 @@
 ---
 layout: default
 ---
+## [next]
+### neue Features
+* Neue `<BookletConfig>` in der Booklet.xml:
+  * `show_reload_button` - Man kann sich in der Applikation selbst einen Reload Button anzeigen lassen, der sich wie der normale Reload Button des Browsers verhält. Dies ist im Zusammenspiel mit dem Kiosk Modus nützlich, da hier die gesamte Browsernavigation ausgeschaltet ist, aber manchmal dennoch ein Reload gebraucht wird. Default: OFF
+
 ## 16.1.2
 ### Bugfixes
 * Doppelte Einträge von Booklets (`tests`) werden im Migrationsskript für 16.1.0 nachträglich bereinigt. Die Abhängigkeiten `test_logs`,`test_reviews`, `units` werden auf dem Eintrag der `tests` Tabelle mit der niedrigsten ID vereinigt.

--- a/docs/pages/booklet-config.md
+++ b/docs/pages/booklet-config.md
@@ -128,6 +128,11 @@ Soll ein Knopf für Vollbild in der Titelleiste angezeigt werden?
  * "ON" - Ja.
  * **"OFF" - Nein.**
 
+### show_reload_button
+Soll ein Knopf für 'Seite neu laden' in der Titelleiste angezeigt werden?
+ * "ON" - Ja.
+ * **"OFF" - Nein.**
+
 ### unit_responses_buffer_time
 Speicherfrequenz für Antworten in Ms.
  * **5000**

--- a/frontend/src/app/shared/services/backend.service.ts
+++ b/frontend/src/app/shared/services/backend.service.ts
@@ -27,8 +27,9 @@ export class BackendService {
       );
   }
 
-  clearCache(): Observable<void> {
-    return this.http.post<void>(`${this.serverUrl}clear-cache`, {});
+  clearCache(...directives: string[]): Observable<void> {
+    const payload = directives.length ? { directives } : {};
+    return this.http.post<void>(`${this.serverUrl}clear-cache`, payload);
   }
 
   getSysStatus(): Observable<SysStatus> {

--- a/frontend/src/app/shared/services/maindata/maindata.service.ts
+++ b/frontend/src/app/shared/services/maindata/maindata.service.ts
@@ -157,7 +157,7 @@ export class MainDataService {
       this._authData$.next(null);
       localStorage.removeItem(localStorageAuthDataKey);
     }
-    this.bs.clearCache();
+    this.bs.clearCache(); // todo this function is not called (subscribe() missing). think about consequences
     setTimeout(() => { window.location.href = '/'; }, 100);
   }
 

--- a/frontend/src/app/shared/shared.module.ts
+++ b/frontend/src/app/shared/shared.module.ts
@@ -78,6 +78,7 @@ import { TemplateContextDirective } from './directives/template-context.directiv
   ]
 })
 export class SharedModule {}
+export { BackendService } from './services/backend.service';
 export { CustomtextService } from './services/customtext/customtext.service';
 export { WebsocketBackendService } from './services/websocket-backend/websocket-backend.service';
 export { MessageDialogComponent } from './components/message-dialog/message-dialog.component';

--- a/frontend/src/app/test-controller/components/test-controller/test-controller.component.html
+++ b/frontend/src/app/test-controller/components/test-controller/test-controller.component.html
@@ -39,7 +39,7 @@
   <button
     mat-button
     (click)="reload()"
-    *ngIf="tcs.booklet?.config?.show_fullscreen_button !== 'OFF'"
+    *ngIf="tcs.booklet?.config?.show_reload_button !== 'OFF'"
     matTooltip="Seite neu laden"
     data-cy="reloadPage">
     <mat-icon>replay</mat-icon>

--- a/frontend/src/app/test-controller/components/test-controller/test-controller.component.html
+++ b/frontend/src/app/test-controller/components/test-controller/test-controller.component.html
@@ -38,6 +38,14 @@
   </button>
   <button
     mat-button
+    (click)="reload()"
+    *ngIf="tcs.booklet?.config?.show_fullscreen_button !== 'OFF'"
+    matTooltip="Seite neu laden"
+    data-cy="reloadPage">
+    <mat-icon>replay</mat-icon>
+  </button>
+  <button
+    mat-button
     (click)="toggleFullScreen()"
     *ngIf="tcs.booklet?.config?.show_fullscreen_button !== 'OFF'"
     matTooltip="Vollbild"

--- a/frontend/src/app/test-controller/components/test-controller/test-controller.component.spec.ts
+++ b/frontend/src/app/test-controller/components/test-controller/test-controller.component.spec.ts
@@ -11,7 +11,7 @@ import { MatSidenavModule } from '@angular/material/sidenav';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { Component } from '@angular/core';
 import {
-  CustomtextService, ConnectionStatus, MainDataService, BookletConfig, TestMode
+  CustomtextService, ConnectionStatus, MainDataService, BookletConfig, TestMode, BackendService as SharedBackendService
 } from '../../../shared/shared.module';
 import { BackendService } from '../../services/backend.service';
 import { CommandService } from '../../services/command.service';
@@ -66,6 +66,8 @@ const MockTestControllerService = {
   resetDataStore: () => {}
 };
 
+const MockSharedBackendService = {};
+
 const MockActivatedRoute = {
   params: routeParams$
 };
@@ -97,6 +99,7 @@ describe('TestControllerComponent', () => {
         { provide: CommandService, useValue: MockCommandService },
         { provide: MainDataService, useValue: MockMainDataService },
         { provide: ActivatedRoute, useValue: MockActivatedRoute },
+        { provide: SharedBackendService, useValue: MockSharedBackendService },
         { provide: 'IS_PRODUCTION_MODE', useValue: false }
       ]
     })

--- a/frontend/src/app/test-controller/components/test-controller/test-controller.component.ts
+++ b/frontend/src/app/test-controller/components/test-controller/test-controller.component.ts
@@ -123,6 +123,10 @@ export class TestControllerComponent implements OnInit, OnDestroy {
     });
   }
 
+  reload() {
+    window.location.reload();
+  }
+
   private startAppFocusLogging() {
     if (!this.tcs.testMode.saveResponses) {
       return;

--- a/frontend/src/app/test-controller/components/test-controller/test-controller.component.ts
+++ b/frontend/src/app/test-controller/components/test-controller/test-controller.component.ts
@@ -21,6 +21,7 @@ import {
   WindowFocusState
 } from '../../interfaces/test-controller.interfaces';
 import { BackendService } from '../../services/backend.service';
+import { BackendService as SharedBackendService } from '../../../shared/shared.module';
 import { TestControllerService } from '../../services/test-controller.service';
 import { ReviewDialogComponent } from '../review-dialog/review-dialog.component';
 import { CommandService } from '../../services/command.service';
@@ -53,6 +54,7 @@ export class TestControllerComponent implements OnInit, OnDestroy {
     public mainDataService: MainDataService,
     public tcs: TestControllerService,
     private bs: BackendService,
+    private sharedBs: SharedBackendService,
     private reviewDialog: MatDialog,
     private snackBar: MatSnackBar,
     private route: ActivatedRoute,
@@ -124,7 +126,9 @@ export class TestControllerComponent implements OnInit, OnDestroy {
   }
 
   reload() {
-    window.location.reload();
+    this.sharedBs.clearCache('cache').subscribe();
+    // @ts-ignore: force reload with 'true' only works for firefox so far, that's why we clear cache manually
+    setTimeout(() => {window.location.reload(true)}, 100);
   }
 
   private startAppFocusLogging() {


### PR DESCRIPTION
### neue Features
* Neue `<BookletConfig>` in der Booklet.xml:
  * `show_reload_button` - Man kann sich in der Applikation selbst einen Reload Button anzeigen lassen, der sich wie der normale Reload Button des Browsers verhält. Dies ist im Zusammenspiel mit dem Kiosk Modus nützlich, da hier die gesamte Browsernavigation ausgeschaltet ist, aber manchmal dennoch ein Reload gebraucht wird. Default: OFF
