### PR TITLE
add opcache

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,8 @@ composer-refresh-autoload:
 	$(MAKE) -f $(MK_FILE_DIR)/dev.mk -C $(MK_FILE_DIR) $@
 re-init-backend:
 	$(MAKE) -f $(MK_FILE_DIR)/dev.mk -C $(MK_FILE_DIR) $@
+connect-db:
+	$(MAKE) -f $(MK_FILE_DIR)/dev.mk -C $(MK_FILE_DIR) $@
 
 create-interfaces:
 	$(MAKE) -f $(MK_FILE_DIR)/dev.mk -C $(MK_FILE_DIR) $@

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -36,7 +36,7 @@ RUN --mount=type=cache,sharing=locked,target=/var/cache/apt \
     apt-get update && apt-get install -y --no-install-recommends \
     libzip-dev
 
-RUN docker-php-ext-install -j$(nproc) pdo_mysql zip
+RUN docker-php-ext-install -j$(nproc) pdo_mysql zip opcache
 RUN pecl install igbinary && docker-php-ext-enable igbinary
 RUN pecl install redis && docker-php-ext-enable redis
 

--- a/backend/composer.json
+++ b/backend/composer.json
@@ -26,7 +26,8 @@
     "ext-redis": "*",
     "ext-simplexml": "*",
     "ext-xmlreader": "*",
-    "ext-zip": "*"
+    "ext-zip": "*",
+    "ext-zend-opcache" : "*"
   },
   "require-dev": {
     "amphp/parallel": "2.2.2",

--- a/backend/config/local.php.ini
+++ b/backend/config/local.php.ini
@@ -6,3 +6,14 @@ display_startup_errors = on
 error_reporting = E_ALL & ~E_NOTICE & ~E_WARNING
 expose_php = Off
 max_file_uploads = 200
+
+opcache.memory_consumption=128
+opcache.interned_strings_buffer=8
+; phpdocument default opcache.max_accelerated_files=4000
+opcache.max_accelerated_files=10000
+; phpdocumetn default opcache.revalidate_freq=60
+opcache.revalidate_freq=2
+opcache.validate_timestamps=1
+opcache.max_file_size=2M
+opcache.enable_cli=1
+opcache.enable=1

--- a/scripts/make/dev.mk
+++ b/scripts/make/dev.mk
@@ -1,5 +1,7 @@
 TC_BASE_DIR := $(shell git rev-parse --show-toplevel)
 
+include $(TC_BASE_DIR)/.env.dev
+
 ## prevents collisions of make target names with possible file names
 .PHONY: init build up down start stop logs composer-install composer-update composer-refresh-autoload re-init-backend\
 	create-interfaces update-docs docs-frontend-compodoc docs-broadcasting-service-compodoc docs-api-specs docs-user\
@@ -121,6 +123,10 @@ composer-refresh-autoload:
 # Re-runs the initialization script of the backend to apply new database patches and re-read the data-dir.
 re-init-backend:
 	docker exec -it testcenter-backend php /var/www/testcenter/backend/initialize.php
+
+## Open DB console
+connect-db:
+	docker exec -it testcenter-db mysql --user=root --password=$(MYSQL_ROOT_PASSWORD) $(MYSQL_DATABASE)
 
 # Creates some interfaces for booklets and test-modes out of the definitions.
 create-interfaces:


### PR DESCRIPTION
- add opcache php extension to cache the php code as bytecode
- reduces the CPU load per request by half
- the downside of showing stale code is not really given, because we don't change php code after deploying a new version of testcenter; with every update the containers are newly built and the cache emptied