### PR TITLE
change TimeRestrictionType in Booklets

### DIFF
--- a/definitions/vo_Booklet.xsd
+++ b/definitions/vo_Booklet.xsd
@@ -121,7 +121,7 @@
   </xs:complexType>
 
   <xs:complexType name="TimeMaxRestrictionType">
-    <xs:attribute name="minutes" type="xs:positiveInteger"/>
+    <xs:attribute name="minutes" type="xs:double"/>
     <xs:attribute name="leave" type="TimeMaxRestrictionLeaveType" default="confirm"/>
   </xs:complexType>
 


### PR DESCRIPTION
- from positiveInteger to Double, as fractions of a minute are needed sometimes
- minutes as unit of time is still used, as to not break existing booklets