### PR TITLE
fix dialog confirmation handling

### DIFF
--- a/frontend/src/app/workspace-admin/files/files.component.ts
+++ b/frontend/src/app/workspace-admin/files/files.component.ts
@@ -144,7 +144,7 @@ export class FilesComponent implements OnInit, OnDestroy {
       });
 
       dialogRef.afterClosed().subscribe(result => {
-        if (result !== false) {
+        if (result === true) {
           this.bs.deleteFiles(this.wds.workspaceId, filesToDelete)
             .subscribe((fileDeletionReport: FileDeletionReport) => {
               const message = [];

--- a/frontend/src/app/workspace-admin/results/results.component.ts
+++ b/frontend/src/app/workspace-admin/results/results.component.ts
@@ -129,15 +129,14 @@ export class ResultsComponent implements OnInit, OnDestroy {
 
       dialogRef.afterClosed()
         .subscribe(result => {
-          if (result === false) {
-            return;
+          if (result === true) {
+            this.backendService.deleteResponses(this.workspaceDataService.workspaceId, selectedGroups)
+              .subscribe(() => {
+                this.snackBar.open('Löschen erfolgreich.', 'OK', { duration: 5000 });
+                this.tableSelectionCheckbox.clear();
+                this.updateTable();
+              });
           }
-          this.backendService.deleteResponses(this.workspaceDataService.workspaceId, selectedGroups)
-            .subscribe(() => {
-              this.snackBar.open('Löschen erfolgreich.', 'OK', { duration: 5000 });
-              this.tableSelectionCheckbox.clear();
-              this.updateTable();
-            });
         });
     }
   }

--- a/frontend/src/app/workspace-admin/syscheck/syscheck.component.ts
+++ b/frontend/src/app/workspace-admin/syscheck/syscheck.component.ts
@@ -110,21 +110,20 @@ export class SyscheckComponent implements OnInit, OnDestroy {
 
       dialogRef.afterClosed()
         .subscribe(result => {
-          if (result === false) {
-            return;
+          if (result === true) {
+            this.bs.deleteSysCheckReports(this.wds.workspaceId, selectedReports)
+              .subscribe(fileDeletionReport => {
+                const message = [];
+                if (fileDeletionReport.deleted.length > 0) {
+                  message.push(`${fileDeletionReport.deleted.length} Berichte erfolgreich gelöscht.`);
+                }
+                if (fileDeletionReport.not_allowed.length > 0) {
+                  message.push(`${fileDeletionReport.not_allowed.length} Berichte konnten nicht gelöscht werden.`);
+                }
+                this.snackBar.open(message.join('<br>'), message.length > 1 ? 'Achtung' : '', { duration: 1000 });
+                this.updateTable();
+              });
           }
-          this.bs.deleteSysCheckReports(this.wds.workspaceId, selectedReports)
-            .subscribe(fileDeletionReport => {
-              const message = [];
-              if (fileDeletionReport.deleted.length > 0) {
-                message.push(`${fileDeletionReport.deleted.length} Berichte erfolgreich gelöscht.`);
-              }
-              if (fileDeletionReport.not_allowed.length > 0) {
-                message.push(`${fileDeletionReport.not_allowed.length} Berichte konnten nicht gelöscht werden.`);
-              }
-              this.snackBar.open(message.join('<br>'), message.length > 1 ? 'Achtung' : '', { duration: 1000 });
-              this.updateTable();
-            });
         });
     }
   }


### PR DESCRIPTION
resolves #1047 

- replace `result !== false` with explicit `result === true` checks for consistency and clarity
- before: the files were also deleted, if you cancel the dialogbox by clicking away