### PR TITLE
[fe] Migrate Dockerfile to @angular/build:application

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -50,7 +50,7 @@ USER root
 RUN chown -R nginx:root /usr/share/nginx/html
 
 USER nginx
-COPY --chown=nginx:root --from=base /usr/src/testcenter/frontend/dist /usr/share/nginx/html
+COPY --chown=nginx:root --from=base /usr/src/testcenter/frontend/dist/browser /usr/share/nginx/html
 COPY --chown=nginx:root frontend/nginx.conf /etc/nginx/templates/default.conf.template
 
 EXPOSE 8080


### PR DESCRIPTION
The new @angular/build:application saves the compiled angular prod files in a ./browser subfolder within the specified outputPath/base. The Dockerfiler now copies the files from the new browser folder. Change was made in Dockerfile instead of the nginx config to keep the convention that servable files are located within the Nginx Container in /usr/share/nginxx/html, without any subfolders.