### PR TITLE
add new indices

### DIFF
--- a/scripts/database/patches.d/17.6.0.sql
+++ b/scripts/database/patches.d/17.6.0.sql
@@ -1,0 +1,6 @@
+-- Optimize polling for commands
+CREATE INDEX `idx_test_commands_execution` ON `test_commands` (`test_id`, `executed`, `timestamp`);
+
+-- Optimize review sorting and filtering
+CREATE INDEX `idx_test_reviews_sorting` ON `test_reviews` (`booklet_id`, `person_id`, `reviewtime`);
+CREATE INDEX `idx_unit_reviews_sorting` ON `unit_reviews` (`test_id`, `unit_name`, `person_id`, `reviewtime`);


### PR DESCRIPTION
here is the breakdown of the indices and the specific code they target:

1. **idx_test_commands_execution**
Index: (test_id, executed, timestamp) 
Target Code: TestDAO::getCommands

SELECT * FROM test_commands WHERE test_id = :test_id AND executed = 0 ORDER BY timestamp

This is a high-frequency polling query. Every active test client polls this endpoint repeatedly to check for new commands. Without this index:
- MySQL finds rows for test_id
- It filters for executed = 0
- It performs a "filesort" (sorting in memory) to order them by timestamp

With the index, the data is already sorted and retrievable instantly. This is critical for scalability when we have thousands of concurrent users polling.

CREATE INDEX `idx_test_commands_execution` ON `test_commands` (`test_id`, `executed`, `timestamp`);

2. **idx_test_reviews_sorting** & **idx_unit_reviews_sorting**

Indices: 
- test_reviews (booklet_id, person_id, reviewtime)
- unit_reviews (test_id, unit_name, person_id, reviewtime)
Target Code: TestDAO::getTestReviews and TestDAO::getUnitReviews

SELECT ... FROM test_reviews 
WHERE booklet_id = :test_id AND person_id = :person_id 
ORDER BY reviewtime DESC

These queries retrieve review history sorted by time. The existing indices likely covered the lookup (WHERE), but not the sorting (ORDER BY).

Without index: MySQL fetches all matching rows and then sorts them in memory.
With index: MySQL reads the rows directly from the index in the correct order, skipping the sorting step entirely.

CREATE INDEX `idx_test_reviews_sorting` ON `test_reviews` (`booklet_id`, `person_id`, `reviewtime`);
CREATE INDEX `idx_unit_reviews_sorting` ON `unit_reviews` (`test_id`, `unit_name`, `person_id`, `reviewtime`);