### PR TITLE
[be] Deleting single tests now affects GET /getResults

### DIFF
--- a/backend/src/dao/AdminDAO.class.php
+++ b/backend/src/dao/AdminDAO.class.php
@@ -133,6 +133,18 @@ class AdminDAO extends DAO {
       $params[":booklet_name_$index"] = $set['bookletName'];
     }
 
+    $affectedGroups = $this->_(
+      "
+      select distinct login_sessions.group_name
+       from tests
+       inner join person_sessions on tests.person_id = person_sessions.id
+       inner join login_sessions on person_sessions.login_sessions_id = login_sessions.id
+       where login_sessions.workspace_id = :workspace_id
+          and (login_sessions.name, person_sessions.code, person_sessions.name_suffix, tests.name) in (" . implode(',', $placeholders) . ")",
+      $params,
+      true
+    );
+
     $this->_(
       "
       delete tests 
@@ -143,6 +155,20 @@ class AdminDAO extends DAO {
           and (login_sessions.name, person_sessions.code, person_sessions.name_suffix, tests.name) in (" . implode(',', $placeholders) . ")" ,
       $params
     );
+
+    foreach ($affectedGroups as $row) {
+      $this->_('
+        update login_session_groups 
+        set last_modified = :now
+        where workspace_id = :workspace_id 
+          and group_name = :group_name',
+        [
+          ':now' => TimeStamp::toSQLFormat(TimeStamp::now()),
+          ':workspace_id' => $workspaceId,
+          ':group_name' => $row['group_name']
+        ]
+      );
+    }
   }
 
   /** @return WorkspaceData[] */
@@ -443,6 +469,8 @@ class AdminDAO extends DAO {
     $groupsPlaceholders = implode(',', array_fill(0, count($groups), '?'));
     $bindParams = array_merge([$workspaceId], $groups, [$workspaceId], $groups);
 
+
+
     // TODO: use data class
     return $this->_("
         SELECT
@@ -570,13 +598,17 @@ class AdminDAO extends DAO {
         max(num_units) as num_units_max,
         sum(num_units) as num_units_total,
         avg(num_units) as num_units_mean,
-        max(timestamp_server) as lastchange
+        GREATEST(
+          max(timestamp_server),
+          max(group_last_modified)
+        ) as lastchange
       from (
         select
           login_sessions.group_name,
           group_label,
           count(distinct units.name, units.test_id) as num_units,
-          max(tests.timestamp_server) as timestamp_server
+          max(tests.timestamp_server) as timestamp_server,
+          login_session_groups.last_modified as group_last_modified
         from
           tests
           left join person_sessions 
@@ -600,7 +632,7 @@ class AdminDAO extends DAO {
               or test_reviews.entry is not null
           )
           and tests.running = 1
-          group by tests.name, person_sessions.id, login_sessions.group_name, group_label
+          group by tests.name, person_sessions.id, login_sessions.group_name, group_label, login_session_groups.last_modified
       ) as byGroup
       group by group_name',
       [

--- a/backend/src/dao/SessionDAO.class.php
+++ b/backend/src/dao/SessionDAO.class.php
@@ -435,12 +435,13 @@ class SessionDAO extends DAO {
   public function getOrCreateGroupToken(int $workspaceId, string $groupName, string $groupLabel): string {
     $newGroupToken = Token::generate('group', $groupName);
     $this->_(
-      'insert ignore into login_session_groups (group_name, workspace_id, group_label, token) values (?, ?, ?, ?)',
+      'insert ignore into login_session_groups (group_name, workspace_id, group_label, token, last_modified) values (?, ?, ?, ?, ?)',
       [
         $groupName,
         $workspaceId,
         $groupLabel,
-        $newGroupToken
+        $newGroupToken,
+        TimeStamp::toSQLFormat(TimeStamp::now())
       ]
     );
 

--- a/backend/test/unit/testdata.sql
+++ b/backend/test/unit/testdata.sql
@@ -22,11 +22,11 @@ insert into logins (name, password, mode, workspace_id, codes_to_booklets, sourc
 values ('future_user', 'pw_hash', 'run-hot-return', 1, '{}', 'testdata.sql', '2030-01-02 10:00:00', '2032-01-02 10:00:00', null, 'sample_group', 'Sample Group', '');
 
 
-insert into login_session_groups (group_label, group_name, token, workspace_id)
-values ('Sample Group', 'sample_group', 'group-token', 1);
+insert into login_session_groups (group_label, group_name, token, workspace_id, last_modified)
+values ('Sample Group', 'sample_group', 'group-token', 1, '1970-01-01 00:00:01');
 
-insert into login_session_groups (group_label, group_name, token, workspace_id)
-values ('Review Group', 'review_group', 'review-group-token', 1);
+insert into login_session_groups (group_label, group_name, token, workspace_id, last_modified)
+values ('Review Group', 'review_group', 'review-group-token', 1, '1970-01-01 00:00:01');
 
 
 insert into login_sessions (name, workspace_id, group_name, token)

--- a/scripts/database/patches.d/next.sql
+++ b/scripts/database/patches.d/next.sql
@@ -1,0 +1,6 @@
+alter table login_session_groups
+  add column last_modified timestamp not null default '1970-01-01 00:00:01';
+
+alter table login_session_groups
+  modify column last_modified timestamp not null;
+


### PR DESCRIPTION
New column in the login_session_groups was added to track timestamp when a single test was deleted - as this cannot be tracked at the test level itself. A deleted test cannot show its last timestamp.

The migration sets all current existing login_session_groups rows to TIMESTAMP's earliest date '1970-01-01 00:00:01'. After the migration, the column is set NOT NULL as to enforce timestamps, when working with the table.

/getResults now shows lastChange as the latest event of either the previos test timestamp calculation or from new column in groups

solves #1200 