### PR TITLE
Fix GM login failure with numeric codes

### DIFF
--- a/backend/src/dao/SessionDAO.class.php
+++ b/backend/src/dao/SessionDAO.class.php
@@ -527,8 +527,9 @@ class SessionDAO extends DAO {
       ]
     );
 
-    $code = $bookletDef['code'];
+    $code = (string) $bookletDef['code'];
     $codes2booklets = JSON::decode($bookletDef['codes_to_booklets'], true);
+    $codes2booklets = array_combine(array_map('strval', array_keys($codes2booklets)), array_values($codes2booklets));
 
     return $codes2booklets and isset($codes2booklets[$code]) and in_array($bookletName, $codes2booklets[$code]);
   }

--- a/backend/src/data-collection/Login.class.php
+++ b/backend/src/data-collection/Login.class.php
@@ -25,6 +25,7 @@ class Login extends DataCollectionTypeSafe {
   ) {
     $this->validForMinutes = $validForMinutes ?? 0;
     $this->customTexts = $customTexts ?? new stdClass();
+    $this->testNames = array_combine(array_map('strval', array_keys($testNames)), array_values($testNames));
   }
 
   public function getName(): string {


### PR DESCRIPTION
## Summary
- Fixes Group Monitor login crash when a purely numeric student code (e.g. `123`) is used
- PHP's `json_decode` with associative array mode converts numeric string keys to integers, causing a `TypeError` in strict mode when passed to methods expecting `string`
- Ensures `testNames` array keys are always strings in the `Login` constructor and in `SessionDAO::personHasBooklet()`

Fixes #1216

## Test plan
- [ ] Create a Testtakers XML with a purely numeric code (e.g. `codes="123"`)
- [ ] Log in as the corresponding Group Monitor — should succeed without 500 error
- [ ] Verify that the test-taker can still log in and select their booklet with the numeric code
- [ ] Run backend unit tests (`make test-backend-unit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)