### PR TITLE
[fe] Hide "Zustände" heading for non-adaptive booklets

### DIFF
--- a/frontend/src/app/test-controller/components/unit-menu/unit-menu.component.html
+++ b/frontend/src/app/test-controller/components/unit-menu/unit-menu.component.html
@@ -32,7 +32,7 @@
 </ng-container>
 
 <div class="sidebar-bottom">
-  <ng-container *ngIf="tcs.testMode.canChangeStateOptions">
+  <ng-container *ngIf="tcs.testMode.canChangeStateOptions && (tcs.booklet?.states | keyvalue)?.length">
     <h3>Zustände</h3>
     <div *ngFor="let state of (tcs.booklet?.states || {}) | keyvalue">
       <mat-form-field>


### PR DESCRIPTION
## Summary
- Only show the "Zustände" (States) heading and its dropdowns when the booklet actually has states defined
- Prevents an empty heading from rendering for non-adaptive booklets
- Adds a check on `(tcs.booklet?.states | keyvalue)?.length` alongside the existing `canChangeStateOptions` condition

Closes #1171

## Test plan
- [ ] Run the app with a non-adaptive booklet → "Zustände" heading should not appear
- [ ] Run the app with an adaptive booklet → "Zustände" heading + dropdowns should appear as before
- [ ] Run frontend unit tests