### PR TITLE
Fix misleading error on uploads with long processing time

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -70,6 +70,9 @@ server {
   # Backend
   location /api/ {
     client_max_body_size 2G;
+    proxy_connect_timeout 60s;
+    proxy_send_timeout 600s;
+    proxy_read_timeout 600s;
     proxy_pass http://backend:8080/;
   }
 }


### PR DESCRIPTION
## Summary
- Adds `proxy_connect_timeout`, `proxy_send_timeout`, and `proxy_read_timeout` directives to the frontend nginx `/api/` location block
- Without these, nginx uses the default 60s timeout which causes a misleading "413 Request Entity Too Large" error when backend file processing/validation takes longer than 60 seconds
- The backend already has high timeouts set for this purpose, but the frontend proxy was not configured accordingly

Closes #1184