### PR TITLE
Fix GM login failure with numeric test-taker codes

### DIFF
--- a/backend/src/data-collection/Login.class.php
+++ b/backend/src/data-collection/Login.class.php
@@ -25,6 +25,10 @@ class Login extends DataCollectionTypeSafe {
   ) {
     $this->validForMinutes = $validForMinutes ?? 0;
     $this->customTexts = $customTexts ?? new stdClass();
+    $this->testNames = array_combine(
+      array_map('strval', array_keys($this->testNames)),
+      array_values($this->testNames)
+    );
   }
 
   public function getName(): string {


### PR DESCRIPTION
## Summary
- Fixes group monitor login failure when purely numeric codes (e.g. `codes="123"`) are used in Testtakers XML
- Root cause: PHP's `json_decode($json, true)` converts numeric string keys to integers, causing a `TypeError` in `SessionDAO::createOrUpdatePersonSession()` which expects `string $code`
- Fix: ensure all `testNames` keys are cast to strings in the `Login` constructor

## Test plan
- [ ] Create a Testtakers XML with a purely numeric code (e.g. `codes="123"`)
- [ ] Login as the group monitor for that group
- [ ] Verify no TypeError / 500 error occurs
- [ ] Verify the test session is correctly created for the numeric code

Closes #1216