### PR TITLE
Fix connection-lost notification from broadcaster

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -70,6 +70,7 @@ server {
   # Backend
   location /api/ {
     client_max_body_size 2G;
+    proxy_set_header X-Forwarded-Prefix /api;
     proxy_pass http://backend:8080/;
   }
 }


### PR DESCRIPTION
## Summary
- After the architecture change routing all traffic through the frontend nginx, the broadcaster's `POST /test/{id}/connection-lost` requests fail with 404
- Root cause: the frontend nginx proxies `/api/*` to the backend but doesn't set `X-Forwarded-Prefix`, so `Server::getUrl()` constructs the `disconnectNotificationUri` without the `/api` prefix
- Fix: add `proxy_set_header X-Forwarded-Prefix /api` to the backend proxy location so the URL is correctly constructed as `/api/test/{id}/connection-lost`

## Test plan
- [ ] Start a test session with WebSocket connection active
- [ ] Go offline (e.g. F12 → Network → Throttle → Offline)
- [ ] Verify that the Group Monitor shows "connection lost" status
- [ ] Check server logs for absence of the nginx 404 error on `/test/{id}/connection-lost`

Closes #1213