### PR TITLE
Fix connection-lost notification from broadcasting service

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -70,6 +70,7 @@ server {
   # Backend
   location /api/ {
     client_max_body_size 2G;
+    proxy_set_header X-Forwarded-Prefix /api;
     proxy_pass http://backend:8080/;
   }
 }


### PR DESCRIPTION
## Summary
- Fixes broadcasting service unable to send `connection-lost` signal to the backend after the change to route all traffic through the frontend
- Root cause: frontend nginx proxies `/api/` to the backend but doesn't pass `X-Forwarded-Prefix`, so `Server::getUrl()` generates URLs without the `/api` prefix
- The broadcasting service then calls `/test/{id}/connection-lost` which has no matching nginx location, returning 404
- Fix: add `proxy_set_header X-Forwarded-Prefix /api` to the backend proxy location

## Test plan
- [ ] Start a test session with WebSocket connection to the broadcasting service
- [ ] Go offline (e.g. via browser DevTools network throttling → offline)
- [ ] Wait for the WebSocket to disconnect
- [ ] Check server logs - should see the connection-lost signal sent successfully, not a 404 error
- [ ] Verify the test session state shows `connection_lost` in the group monitor

Closes #1213