### PR TITLE
Add optional group filter to results endpoint

### DIFF
--- a/backend/src/controller/WorkspaceController.class.php
+++ b/backend/src/controller/WorkspaceController.class.php
@@ -74,7 +74,8 @@ class WorkspaceController extends Controller {
 
   public static function getResults(Request $request, Response $response): Response {
     $workspaceId = (int) $request->getAttribute('ws_id');
-    $results = self::adminDAO()->getResultStats($workspaceId);
+    $groupName = $request->getQueryParams()['group'] ?? null;
+    $results = self::adminDAO()->getResultStats($workspaceId, $groupName);
 
     return $response->withJson($results);
   }

--- a/backend/src/dao/AdminDAO.class.php
+++ b/backend/src/dao/AdminDAO.class.php
@@ -560,8 +560,14 @@ class AdminDAO extends DAO {
     );
   }
 
-  public function getResultStats(int $workspaceId): array {
-    $resultStats = $this->_('
+  public function getResultStats(int $workspaceId, ?string $groupName = null): array {
+    $groupFilter = $groupName ? 'and login_sessions.group_name = :groupName' : '';
+    $params = [':workspaceId' => $workspaceId];
+    if ($groupName) {
+      $params[':groupName'] = $groupName;
+    }
+
+    $resultStats = $this->_("
       select
         group_name,
         group_label,
@@ -579,7 +585,7 @@ class AdminDAO extends DAO {
           max(tests.timestamp_server) as timestamp_server
         from
           tests
-          left join person_sessions 
+          left join person_sessions
             on person_sessions.id = tests.person_id
           inner join login_sessions
             on login_sessions.id = person_sessions.login_sessions_id
@@ -589,11 +595,12 @@ class AdminDAO extends DAO {
             on units.name = unit_reviews.unit_name and unit_reviews.test_id = units.test_id
           left join test_reviews
             on tests.id = test_reviews.booklet_id
-          left join login_session_groups on 
+          left join login_session_groups on
             login_sessions.group_name = login_session_groups.group_name
               and login_sessions.workspace_id = login_session_groups.workspace_id
         where
           login_sessions.workspace_id = :workspaceId
+          $groupFilter
           and (
             tests.laststate is not null
               or unit_reviews.entry is not null
@@ -602,10 +609,8 @@ class AdminDAO extends DAO {
           and tests.running = 1
           group by tests.name, person_sessions.id, login_sessions.group_name, group_label
       ) as byGroup
-      group by group_name',
-      [
-        ':workspaceId' => $workspaceId
-      ],
+      group by group_name",
+      $params,
       true
     );
 

--- a/docs/api/workspace.spec.yml
+++ b/docs/api/workspace.spec.yml
@@ -323,6 +323,12 @@ paths:
           required: true
           schema:
             type: integer
+        - in: query
+          name: group
+          description: filter results by group name
+          required: false
+          schema:
+            type: string
 
       responses:
         "200":


### PR DESCRIPTION
## Summary
- Adds an optional `group` query parameter to `GET /workspace/{ws_id}/results`
- When provided, only results for the specified group are returned
- Backward compatible: omitting the parameter returns all groups as before
- Also updates the API spec to document the new query parameter

Example: `GET /workspace/1/results?group=my_group`

## Test plan
- [ ] `GET /workspace/{ws_id}/results` without `group` parameter returns all groups (unchanged behavior)
- [ ] `GET /workspace/{ws_id}/results?group=existing_group` returns only that group's results
- [ ] `GET /workspace/{ws_id}/results?group=nonexistent_group` returns an empty array

Closes #1199