### PR TITLE
Fix frontend coverage report artifact path in CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1085,7 +1085,7 @@ test-frontend-unit:
     - docker logout $REGISTRY
   artifacts:
     paths:
-      - docs/dist/test-coverage-frontend-unit/*
+      - docs/dist/test-coverage-frontend-unit/**/*
     expire_in: 30 minutes
 
 test-broadcaster-unit:


### PR DESCRIPTION
## Summary
- The frontend karma config writes coverage to a `report/` subdirectory (`subdir: 'report'` in karma.conf.js)
- The CI artifact path used `docs/dist/test-coverage-frontend-unit/*` which only captures top-level files, missing the `report/` subdirectory
- Changed to `docs/dist/test-coverage-frontend-unit/**/*` to recursively capture all files including the report subdirectory

## Test plan
- [ ] Run the `test-frontend-unit` CI job
- [ ] Verify the artifacts include `docs/dist/test-coverage-frontend-unit/report/index.html`
- [ ] After pages deployment, verify the coverage report link works: `dist/test-coverage-frontend-unit/report/index.html`

Closes #1203