### PR TITLE
[be] Add group filter to GET results endpoint

### DIFF
--- a/backend/src/controller/WorkspaceController.class.php
+++ b/backend/src/controller/WorkspaceController.class.php
@@ -74,7 +74,10 @@ class WorkspaceController extends Controller {
 
   public static function getResults(Request $request, Response $response): Response {
     $workspaceId = (int) $request->getAttribute('ws_id');
-    $results = self::adminDAO()->getResultStats($workspaceId);
+    $groups = $request->getParam('groups', '') === ''
+      ? []
+      : explode(',', $request->getParam('groups', ''));
+    $results = self::adminDAO()->getResultStats($workspaceId, $groups);
 
     return $response->withJson($results);
   }

--- a/backend/src/dao/AdminDAO.class.php
+++ b/backend/src/dao/AdminDAO.class.php
@@ -560,8 +560,21 @@ class AdminDAO extends DAO {
     );
   }
 
-  public function getResultStats(int $workspaceId): array {
-    $resultStats = $this->_('
+  public function getResultStats(int $workspaceId, array $groups = []): array {
+    $groupFilter = '';
+    $params = [':workspaceId' => $workspaceId];
+
+    if (count($groups)) {
+      $placeholders = [];
+      foreach ($groups as $index => $group) {
+        $key = ":group$index";
+        $placeholders[] = $key;
+        $params[$key] = $group;
+      }
+      $groupFilter = 'and login_sessions.group_name in (' . implode(',', $placeholders) . ')';
+    }
+
+    $resultStats = $this->_("
       select
         group_name,
         group_label,
@@ -579,7 +592,7 @@ class AdminDAO extends DAO {
           max(tests.timestamp_server) as timestamp_server
         from
           tests
-          left join person_sessions 
+          left join person_sessions
             on person_sessions.id = tests.person_id
           inner join login_sessions
             on login_sessions.id = person_sessions.login_sessions_id
@@ -589,11 +602,12 @@ class AdminDAO extends DAO {
             on units.name = unit_reviews.unit_name and unit_reviews.test_id = units.test_id
           left join test_reviews
             on tests.id = test_reviews.booklet_id
-          left join login_session_groups on 
+          left join login_session_groups on
             login_sessions.group_name = login_session_groups.group_name
               and login_sessions.workspace_id = login_session_groups.workspace_id
         where
           login_sessions.workspace_id = :workspaceId
+          $groupFilter
           and (
             tests.laststate is not null
               or unit_reviews.entry is not null
@@ -602,10 +616,8 @@ class AdminDAO extends DAO {
           and tests.running = 1
           group by tests.name, person_sessions.id, login_sessions.group_name, group_label
       ) as byGroup
-      group by group_name',
-      [
-        ':workspaceId' => $workspaceId
-      ],
+      group by group_name",
+      $params,
       true
     );
 

--- a/docs/api/workspace.spec.yml
+++ b/docs/api/workspace.spec.yml
@@ -323,6 +323,13 @@ paths:
           required: true
           schema:
             type: integer
+        - in: query
+          name: groups
+          description: comma-separated list of group names to filter results by
+          required: false
+          schema:
+            type: string
+          example: "sample_group,review_group"
 
       responses:
         "200":


### PR DESCRIPTION
## Summary
- Adds optional `groups` query parameter to `GET /workspace/{ws_id}/results`
- Accepts a comma-separated list of group names (e.g. `?groups=group1,group2`)
- When omitted, returns all groups (fully backwards compatible)
- Uses parameterized SQL queries for safe group name filtering

## Test plan
- [ ] `GET /workspace/1/results` returns all groups (unchanged behavior)
- [ ] `GET /workspace/1/results?groups=sample_group` returns only the specified group
- [ ] `GET /workspace/1/results?groups=group1,group2` returns multiple specified groups
- [ ] `GET /workspace/1/results?groups=nonexistent` returns empty array
- [ ] Verify API docs render the new parameter correctly

Closes #1199