### PR TITLE
Fix config.ini parsing failure with special characters in values

### DIFF
--- a/backend/src/helper/SystemConfig.class.php
+++ b/backend/src/helper/SystemConfig.class.php
@@ -137,7 +137,11 @@ class SystemConfig {
         if (($key == 'version') and (getEnv('VERSION') !== self::$system_version)) {
           continue;
         }
-        $value = is_bool($value) ? ($value ? 'yes' : 'no') : $value;
+        if (is_bool($value)) {
+          $value = $value ? 'yes' : 'no';
+        } elseif (is_string($value)) {
+          $value = '"' . addcslashes($value, '"') . '"';
+        }
         $output .= "$key=$value\n";
       }
     }


### PR DESCRIPTION
## Summary
- `SystemConfig::write()` now wraps string values in double quotes when writing `config.ini`
- This fixes `parse_ini_file()` failures when values contain special characters like `=` (common in base64-encoded Redis passwords from Azure)
- `parse_ini_file()` automatically strips the quotes when reading, so this is backward compatible

## Test plan
- [ ] Set a Redis password containing `=` (e.g. base64-encoded) via `REDIS_PASSWORD` env var
- [ ] Start the backend and verify it can read the config correctly
- [ ] Verify existing configs without special characters still work

Closes #1115