### PR TITLE
Fix time unit capitalization in booklet config (Ms -> ms)

### DIFF
--- a/definitions/booklet-config.json
+++ b/definitions/booklet-config.json
@@ -168,17 +168,17 @@
     "defaultvalue": "OFF"
   },
   "unit_responses_buffer_time": {
-    "label": "Speicherfrequenz für Antworten in Ms.",
+    "label": "Speicherfrequenz für Antworten in ms.",
     "options": {},
     "defaultvalue": "5000"
   },
   "unit_state_buffer_time": {
-    "label": "Speicherfrequenz für Unit-Zustände (zB responseProgress etc.) in Ms.",
+    "label": "Speicherfrequenz für Unit-Zustände (zB responseProgress etc.) in ms.",
     "options": {},
     "defaultvalue": "6000"
   },
   "test_state_buffer_time": {
-    "label": "Speicherfrequenz für Test-Zustände in Ms.",
+    "label": "Speicherfrequenz für Test-Zustände in ms.",
     "options": {},
     "defaultvalue": "1000"
   },

--- a/docs/pages/booklet-config.md
+++ b/docs/pages/booklet-config.md
@@ -134,15 +134,15 @@ Soll ein Knopf für 'Seite neu laden' in der Titelleiste angezeigt werden?
  * **"OFF" - Nein.**
 
 ### unit_responses_buffer_time
-Speicherfrequenz für Antworten in Ms.
+Speicherfrequenz für Antworten in ms.
  * **5000**
 
 ### unit_state_buffer_time
-Speicherfrequenz für Unit-Zustände (zB responseProgress etc.) in Ms.
+Speicherfrequenz für Unit-Zustände (zB responseProgress etc.) in ms.
  * **6000**
 
 ### test_state_buffer_time
-Speicherfrequenz für Test-Zustände in Ms.
+Speicherfrequenz für Test-Zustände in ms.
  * **1000**
 
 ### ui_mode


### PR DESCRIPTION
## Summary
- Corrects "Ms." (uppercase M) to "ms." (lowercase, proper SI unit for milliseconds) in booklet config labels
- Fixes the labels in `definitions/booklet-config.json` and `docs/pages/booklet-config.md`
- SysCheck report labels (`RoundTrip in Ms`) are intentionally **not** changed to avoid a breaking change in CSV exports (as noted in the issue discussion)

Closes #1126