### PR TITLE
[file-server] Declare wsId as local variable in auth.lua

### DIFF
--- a/file-server/auth/auth.lua
+++ b/file-server/auth/auth.lua
@@ -7,6 +7,7 @@ local uri = ngx.var.uri
 
 local fileName
 local token
+local wsId
 
 token, wsId, fileName = string.match(uri, "^/file/([^/]+)/ws_(%d+)/Resource/(.+)$")
 


### PR DESCRIPTION
## Summary
- Adds missing `local` declaration for `wsId` variable in `file-server/auth/auth.lua`
- Without `local`, `wsId` leaks into global scope, which could cause issues with concurrent requests in nginx/OpenResty

## Test plan
- [ ] File server authentication continues to work correctly
- [ ] Resource file requests are served as expected

Closes #1037