### PR TITLE
[be] Fix array-to-string conversion in initialize.php

### DIFF
--- a/backend/initialize.php
+++ b/backend/initialize.php
@@ -215,7 +215,7 @@ try {
     if (!$args['skip_read_workspace_files']) {
       $stats = $sampleWorkspace->storeAllFiles();
       $sampleWorkspace->setWorkspaceHash();
-      CLI::p("{$stats['valid']} files were stored.");
+      CLI::p(array_sum($stats['valid']) . ' files were stored.');
     }
 
     CLI::success("Sample content files created.");


### PR DESCRIPTION
## Summary
- `$stats['valid']` is an associative array keyed by file type (Resource, Unit, Booklet, etc.), not a scalar
- Using it directly in a string interpolation caused a PHP Array-to-String conversion notice
- Fixed by using `array_sum()` to get the total count of valid files

## Test plan
- [ ] Run initialization with sample data: no PHP notice/warning about Array-to-String conversion
- [ ] Output shows correct total count of stored files

Closes #1030