### PR TITLE
[be] Quote config.ini values to support special characters

### DIFF
--- a/backend/src/helper/SystemConfig.class.php
+++ b/backend/src/helper/SystemConfig.class.php
@@ -138,7 +138,7 @@ class SystemConfig {
           continue;
         }
         $value = is_bool($value) ? ($value ? 'yes' : 'no') : $value;
-        $output .= "$key=$value\n";
+        $output .= "$key=\"$value\"\n";
       }
     }
     file_put_contents(ROOT_DIR . '/backend/config/config.ini', $output);


### PR DESCRIPTION
## Summary
- `SystemConfig::write()` wrote config values without quoting, causing `parse_ini_file()` to fail when values contained `=` characters
- This affected Azure Redis Cache deployments where passwords end with `=` (base64 padding)
- Fix: wrap all values in double quotes in the generated config.ini

## Test plan
- [ ] Set `REDIS_PASSWORD` to a value containing `=` (e.g. `mypassword==`)
- [ ] Start the backend - should initialize without "Application config file is missing!" error
- [ ] Verify config.ini is generated with quoted values
- [ ] Existing deployments continue to work (double quotes around values don't affect parsing)

Closes #1115