### PR TITLE
Declare wsId as local variable in auth.lua

### DIFF
--- a/file-server/auth/auth.lua
+++ b/file-server/auth/auth.lua
@@ -7,6 +7,7 @@ local uri = ngx.var.uri
 
 local fileName
 local token
+local wsId
 
 token, wsId, fileName = string.match(uri, "^/file/([^/]+)/ws_(%d+)/Resource/(.+)$")
 


### PR DESCRIPTION
## Summary
- Adds `local` declaration for `wsId` variable in `file-server/auth/auth.lua`
- Without `local`, the variable pollutes the global scope which can cause issues in nginx's Lua module

Closes #1037