### PR TITLE
Fix array-to-string conversion in initialize.php

### DIFF
--- a/backend/initialize.php
+++ b/backend/initialize.php
@@ -215,7 +215,7 @@ try {
     if (!$args['skip_read_workspace_files']) {
       $stats = $sampleWorkspace->storeAllFiles();
       $sampleWorkspace->setWorkspaceHash();
-      CLI::p("{$stats['valid']} files were stored.");
+      CLI::p(array_sum($stats['valid']) . ' files were stored.');
     }
 
     CLI::success("Sample content files created.");


### PR DESCRIPTION
## Summary
- Fixes PHP warning caused by interpolating an array directly into a string
- Uses `array_sum()` to correctly sum up the file counts from the stats array

Closes #1030