### PR TITLE
[be] Add group authorization to monitor command endpoint

### DIFF
--- a/backend/src/controller/MonitorController.class.php
+++ b/backend/src/controller/MonitorController.class.php
@@ -58,6 +58,7 @@ class MonitorController extends Controller {
     /* @var $authToken AuthToken */
     $authToken = $request->getAttribute('AuthToken');
     $personId = $authToken->getId();
+    $allowedGroups = array_keys($request->getAttribute('groups'));
 
     $body = RequestHelper::getFields($request, [
       'keyword' => 'REQUIRED',
@@ -69,9 +70,10 @@ class MonitorController extends Controller {
     $command = new Command(-1, $body['keyword'], (int) $body['timestamp'], ...$body['arguments']);
 
     foreach (array_unique($body['testIds']) as $testId) {
-      if (!self::adminDAO()->getTest($testId)) {
-        throw new HttpNotFoundException(
-          $request, "Test `$testId` not found. `{$command->getKeyword()}` not committed."
+      $testSession = self::testDAO()->getTestSession($testId);
+      if (!in_array($testSession['group_name'], $allowedGroups)) {
+        throw new HttpForbiddenException(
+          $request, "Access denied for test `$testId`. `{$command->getKeyword()}` not committed."
         );
       }
     }


### PR DESCRIPTION
## Summary
- The `PUT /command` endpoint allowed any group monitor to send commands (lock, unlock, navigate, etc.) to any test in the workspace, regardless of group membership
- This was identified in a penetration test (IBBW report W_02)
- Now validates that each target test belongs to one of the monitor's authorized groups before executing
- Uses the same `groups` attribute set by `IsGroupMonitor` middleware
- Consistent with the existing authorization checks in `postUnlock` and `postLock`

## Test plan
- [ ] Group monitor can send commands to tests in their own group
- [ ] Group monitor receives 403 when trying to send commands to tests in another group
- [ ] Study monitor (`monitor-study`) can still send commands to tests in all groups of the workspace
- [ ] Existing e2e tests pass

Closes #82