### PR TITLE
Add optional group filter to GET /workspace/{ws_id}/results

### DIFF
--- a/backend/src/controller/WorkspaceController.class.php
+++ b/backend/src/controller/WorkspaceController.class.php
@@ -74,7 +74,10 @@ class WorkspaceController extends Controller {
 
   public static function getResults(Request $request, Response $response): Response {
     $workspaceId = (int) $request->getAttribute('ws_id');
-    $results = self::adminDAO()->getResultStats($workspaceId);
+    $groups = $request->getParam('groups', '') === ''
+      ? []
+      : explode(',', $request->getParam('groups', ''));
+    $results = self::adminDAO()->getResultStats($workspaceId, $groups);
 
     return $response->withJson($results);
   }

--- a/backend/src/dao/AdminDAO.class.php
+++ b/backend/src/dao/AdminDAO.class.php
@@ -560,8 +560,21 @@ class AdminDAO extends DAO {
     );
   }
 
-  public function getResultStats(int $workspaceId): array {
-    $resultStats = $this->_('
+  public function getResultStats(int $workspaceId, array $groups = []): array {
+    $groupFilter = '';
+    $params = [':workspaceId' => $workspaceId];
+
+    if (count($groups)) {
+      $placeholders = [];
+      foreach ($groups as $index => $group) {
+        $key = ":group$index";
+        $placeholders[] = $key;
+        $params[$key] = $group;
+      }
+      $groupFilter = 'and login_sessions.group_name in (' . implode(',', $placeholders) . ')';
+    }
+
+    $resultStats = $this->_("
       select
         group_name,
         group_label,
@@ -579,7 +592,7 @@ class AdminDAO extends DAO {
           max(tests.timestamp_server) as timestamp_server
         from
           tests
-          left join person_sessions 
+          left join person_sessions
             on person_sessions.id = tests.person_id
           inner join login_sessions
             on login_sessions.id = person_sessions.login_sessions_id
@@ -589,11 +602,12 @@ class AdminDAO extends DAO {
             on units.name = unit_reviews.unit_name and unit_reviews.test_id = units.test_id
           left join test_reviews
             on tests.id = test_reviews.booklet_id
-          left join login_session_groups on 
+          left join login_session_groups on
             login_sessions.group_name = login_session_groups.group_name
               and login_sessions.workspace_id = login_session_groups.workspace_id
         where
           login_sessions.workspace_id = :workspaceId
+          $groupFilter
           and (
             tests.laststate is not null
               or unit_reviews.entry is not null
@@ -602,10 +616,8 @@ class AdminDAO extends DAO {
           and tests.running = 1
           group by tests.name, person_sessions.id, login_sessions.group_name, group_label
       ) as byGroup
-      group by group_name',
-      [
-        ':workspaceId' => $workspaceId
-      ],
+      group by group_name",
+      $params,
       true
     );
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,11 @@
 ---
 layout: default
 ---
+## [next]
+### Verbesserungen
+* GET /workspace/{ws_id}/results
+  * Dieser Endpunkt nimmt nun einen Parameter `?groups=`, der eine Komma-separierte Liste annimmt, mit Namen von TT-Gruppen (group_name), um die Results nur dieser Gruppen anzuzeigen, statt alle Gruppen gleichzeitig zu ziehen. Wird der Parameter ausgelassen, werden wie zuvor alle Gruppen gelistet (rückwärtskompatibel)
+
 ## 17.5.3
 * Review-Modus:
   * Teilaufgaben-Feld wird nicht mehr automatisch befüllt, da diese nicht anhand der aktuellen Seite ablesbar ist.

--- a/docs/api/workspace.spec.yml
+++ b/docs/api/workspace.spec.yml
@@ -323,6 +323,13 @@ paths:
           required: true
           schema:
             type: integer
+        - in: query
+          name: groups
+          description: comma-separated list of group names to filter results by
+          required: false
+          schema:
+            type: string
+          example: "sample_group,review_group"
 
       responses:
         "200":


### PR DESCRIPTION
Adds a 'groups' query parameter that accepts a comma-separated list of group names to filter results by. When omitted, the endpoint returns results for all groups (backwards compatible).

This allows clients to poll for changes in specific groups without fetching the entire workspace's results, improving performance for large workspaces.

Closes #1199