### PR TITLE
[be] Fix GM login failure when purely numeric codes are used

### DIFF
--- a/backend/src/controller/SessionController.class.php
+++ b/backend/src/controller/SessionController.class.php
@@ -99,7 +99,7 @@ class SessionController extends Controller {
 
     $loginSession = self::sessionDAO()->getLoginSessionByToken(self::authToken($request)->getToken());
 
-    $personSession = self::sessionDAO()->createOrUpdatePersonSession($loginSession, $body['code']);
+    $personSession = self::sessionDAO()->createOrUpdatePersonSession($loginSession, (string)$body['code']);
     CacheService::removeAuthentication($personSession);
     $testsOfPerson = self::sessionDAO()->getTestsOfPerson($personSession);
     CacheService::storeAuthentication($personSession);
@@ -131,7 +131,7 @@ class SessionController extends Controller {
 
       $membersBooklets = $member->getLogin()->testNames();
       foreach ($membersBooklets as $code => $testNames) {
-        $memberPersonSession = SessionController::sessionDAO()->createOrUpdatePersonSession($member, $code, true, false);
+        $memberPersonSession = SessionController::sessionDAO()->createOrUpdatePersonSession($member, (string)$code, true, false);
 
         foreach ($testNames as $testNameStr) {
           /** @var $testNameStr string */

--- a/backend/test/massive-test-data.php
+++ b/backend/test/massive-test-data.php
@@ -173,7 +173,7 @@ try {
         }
 
         if (method_exists($sessionDAO, 'createOrUpdatePersonSession')) {
-          $personSession = $sessionDAO->createOrUpdatePersonSession($loginSession, $code);
+          $personSession = $sessionDAO->createOrUpdatePersonSession($loginSession, (string) $code);
           $personSessions[] = $personSession;
           if ($reLoginIndex > DUPLICATE_PERSON_SESSIONS_PER_RESTART_LOGIN) {
             $sessionDAO->_("update person_sessions set name_suffix='1' where id=" . $personSession->getPerson()->getId());


### PR DESCRIPTION
PHP's json_decode with associative array flag converts numeric string keys to integers, causing a TypeError when the code is passed to methods expecting string parameters.

Fixes #1216