### PR TITLE
[fe] Add booklet config to prevent leaving Unit with browser functionality

### DIFF
--- a/common/src/classes/booklet-config-data.class.ts
+++ b/common/src/classes/booklet-config-data.class.ts
@@ -2,6 +2,7 @@
 export class BookletConfigData {
   loading_mode: 'LAZY' | 'EAGER' = 'LAZY';
   logPolicy: 'disabled' | 'lean' | 'rich' | 'debug' = 'rich';
+  browserBehaviour: 'standard' | 'preventNav' = 'standard';
   pagingMode: 'separate' | 'concat-scroll' | 'concat-scroll-snap' = 'separate';
   page_navibuttons: 'OFF' | 'INDEX' | 'FULL' = 'INDEX';
   unit_navibuttons: 'OFF' | 'INDEX' | 'LABEL' = 'INDEX';

--- a/definitions/booklet-config.json
+++ b/definitions/booklet-config.json
@@ -17,6 +17,14 @@
     },
     "defaultvalue": "rich"
   },
+  "browserBehaviour": {
+    "label": "Verhalten bei Browser-Navigation",
+    "options": {
+      "standard": "Standardverhalten des Browsers verwenden",
+      "preventNav": "Navigationselemente des Browsers (Zurück Button, direkte URL Eingabe) werden im Testverlauf verhindert"
+    },
+    "defaultvalue": "standard"
+  },
   "pagingMode": {
     "label": "pagingMode (https://verona-interfaces.github.io/player/#operation-publish-vopStartCommand)",
     "options": {

--- a/docs/pages/booklet-config.md
+++ b/docs/pages/booklet-config.md
@@ -34,6 +34,11 @@ Erfassen und Speichern von Log-Daten
  * **"rich" - Alles außer debug-Informationen**
  * "debug" - Auch debug-Informationen
 
+### browserBehaviour
+Verhalten bei Browser-Navigation
+ * **"standard" - Standardverhalten des Browsers verwenden**
+ * "preventNav" - Navigationselemente des Browsers (Zurück Button, direkte URL Eingabe) werden im Testverlauf verhindertNavigationselemente des Browsers (Zurück Button, direkte URL Eingabe) werden im Testverlauf verhindert
+
 ### pagingMode
 pagingMode (https://verona-interfaces.github.io/player/#operation-publish-vopStartCommand)
  * **"separate" - pages are separated**
@@ -49,8 +54,8 @@ Navigationsbuttons für die Seitennavigation (innerhalb einer Aufgabe)
 ### unit_navibuttons
 Navigationsbuttons für die Navigation zwischen den Aufgaben
  * "OFF" - Keine Buttons für Aufgabennavigation anzeigen (übernimmt ggf. die Aufgabe selbst)
- * "INDEX" - Der index der aktuellen Aufgabe und die Gesamtzahl an Aufgaben,
- * **"LABEL" - Der Anzeigename der aktuellen Aufgabe wird angezeigt**
+ * **"INDEX" - Der index der aktuellen Aufgabe und die Gesamtzahl an Aufgaben**
+ * "LABEL" - Der Anzeigename der aktuellen Aufgabe wird angezeigt
 
 ### unit_menu
 Der Knopf- für die Unit-Menü-Sidebar soll angezeigt werden

--- a/frontend/src/app/test-controller/routing/unit-deactivate.guard.ts
+++ b/frontend/src/app/test-controller/routing/unit-deactivate.guard.ts
@@ -2,8 +2,9 @@ import { Injectable } from '@angular/core';
 import {
   ActivatedRouteSnapshot, CanDeactivate, Router, RouterStateSnapshot
 } from '@angular/router';
-import { Observable } from 'rxjs';
+import { Observable, of, tap } from 'rxjs';
 // eslint-disable-next-line import/no-cycle
+import { Location } from '@angular/common';
 import { UnithostComponent } from '../components/unithost/unithost.component';
 import { TestControllerService } from '../services/test-controller.service';
 
@@ -11,7 +12,8 @@ import { TestControllerService } from '../services/test-controller.service';
 export class UnitDeactivateGuard implements CanDeactivate<UnithostComponent> {
   constructor(
     private tcs: TestControllerService,
-    private router: Router
+    private router: Router,
+    private location: Location
   ) {}
 
   canDeactivate(
@@ -20,6 +22,17 @@ export class UnitDeactivateGuard implements CanDeactivate<UnithostComponent> {
     currentState: RouterStateSnapshot,
     nextState: RouterStateSnapshot
   ): Observable<boolean> {
+    // 'popstate' for browser triggers, 'imperative' for angular router triggers - not in official documentation
+    // https://angular.love/angular-router-everything-you-need-to-know-about
+    const trigger = this.router.currentNavigation()?.trigger;
+    const preventNav = this.tcs.booklet?.config.browserBehaviour === 'preventNav';
+    // 'popstate' are all browser-based navigation; not including 'imperative' means that regular Angular-handled
+    // navigationRequests don't lead to a new entry on the history stack, hence no pollution
+    if (trigger === 'popstate' && preventNav) {
+      this.location.go(currentState.url);
+      return of(false);
+    }
+
     return this.tcs.canDeactivateUnit(nextState.url);
   }
 }


### PR DESCRIPTION
Add a new booklet config to disable browser native navigation.

When leaving the current unit with a browser function (back, forward, URL input),  the navigation attempt pops the most current URL from the history stack and moves the head one entry into the past. This would inevitably lead the head to reach a URL on the stack that is not handled by Angular anymore, like 'testcenter.de' -> which would call the starter component again -- effectively leaving the current unit. By pushing a new entry of the current URL onto the history stack, the URL head practically stays still on the current unit. Effectively making it possible to leave the test early.