### PR TITLE
[e2e] Add re-init-backend step to dev.mk for improved dev work

### DIFF
--- a/scripts/make/dev.mk
+++ b/scripts/make/dev.mk
@@ -145,6 +145,7 @@ data-pull:
 			--file docker-compose.yml\
 			--file docker-compose.dev.yml\
 		cp backend:/var/www/testcenter/data .
+	$(MAKE) -f $(firstword $(MAKEFILE_LIST)) re-init-backend
 
 # Copies the local data folder into the Backend Container, while keeping the same user-, group- and file permissions
 # from https://blog.nashcom.de/nashcomblog.nsf/dx/docker-cp-with-permissions-and-owner-change.htm


### PR DESCRIPTION
Using $(MAKE) instead of writing make directly is the recommended way, because it preserves flags and options from the parent invocation.

$(MAKEFILE_LIST) is a special variable containing all Makefiles that have been read. $(firstword ...) takes the first one from that list. So this part means: use the first Makefile that was loaded.