### PR TITLE
Fix direct login via URL

### DIFF
--- a/frontend/src/app/app-route-guards.ts
+++ b/frontend/src/app/app-route-guards.ts
@@ -63,7 +63,7 @@ export class DirectLoginActivateGuard {
   canActivate(next: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<boolean> | boolean {
     const name = state.url.substr(1);
     if (name.length > 0 && name.indexOf('/') < 0) {
-      return this.bs.login('login', name)
+      return this.bs.login(name)
         .pipe(
           map((authDataResponse: AuthData) => {
             this.mds.setAuthData(authDataResponse as AuthData);


### PR DESCRIPTION
DirectLoginActivateGuard falsly called the old API for backendService.login(). The old version took in (<type of login>, <loginName>), the new login() takes (<name>, <password>). The admin login was moved entirely to adminLogin().