### PR TITLE
[fe] Add proxy timeout settings to frontend nginx config

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -70,6 +70,9 @@ server {
   # Backend
   location /api/ {
     client_max_body_size 2G;
+    proxy_connect_timeout 60s;
+    proxy_send_timeout 600s;
+    proxy_read_timeout 600s;
     proxy_pass http://backend:8080/;
   }
 }


### PR DESCRIPTION
Fixes misleading "413 Request Entity Too Large" error when backend processing takes longer than the default 60s nginx proxy timeout.

Closes #1184