### PR TITLE
[fe] 'Testung beenden' routes to /starter

### DIFF
--- a/frontend/src/app/group-monitor/group-monitor.component.ts
+++ b/frontend/src/app/group-monitor/group-monitor.component.ts
@@ -259,7 +259,7 @@ export class GroupMonitorComponent implements OnInit, OnDestroy {
             throw err;
           }))
           .subscribe(() => {
-            setTimeout(() => { this.router.navigateByUrl('/r/login'); }, 2000);
+            setTimeout(() => { this.router.navigateByUrl('/r/starter'); }, 2000);
           });
       }
     });


### PR DESCRIPTION
Routing to /login was unexpected and unnicessary. Just route to /starter and let the user decide what to do next.

fixes #1130 