### PR TITLE
[fe] Change unit deactive guard to use messaging service

### DIFF
--- a/frontend/src/app/test-controller/components/test-status/test-status.component.html
+++ b/frontend/src/app/test-controller/components/test-status/test-status.component.html
@@ -1,4 +1,6 @@
 <div [ngSwitch]="(tcs.state$ | async)" class="flex-row-wrap" [style.justify-content]="'center'">
+  <!-- This case should be dead code as the confirm dialog appears on route deactivation, so the
+       test-status route may never be reached.-->
   <mat-card appearance="raised" class="mat-card-box" *ngSwitchDefault>
     <mat-card-header>
       <mat-card-title>{{ tcs.booklet?.metadata?.label }}</mat-card-title>

--- a/frontend/src/app/test-controller/routing/unit-deactivate.guard.ts
+++ b/frontend/src/app/test-controller/routing/unit-deactivate.guard.ts
@@ -7,11 +7,17 @@ import { Observable, of, tap } from 'rxjs';
 import { Location } from '@angular/common';
 import { UnithostComponent } from '../components/unithost/unithost.component';
 import { TestControllerService } from '../services/test-controller.service';
+import { TestControllerState } from '@app/test-controller/interfaces/test-controller.interfaces';
+import { MessageService } from '@shared/services/message.service';
+import { switchMap } from 'rxjs/operators';
+import { CustomtextService } from '@shared/services/customtext/customtext.service';
 
 @Injectable()
 export class UnitDeactivateGuard implements CanDeactivate<UnithostComponent> {
   constructor(
     private tcs: TestControllerService,
+    private messageService: MessageService,
+    private cts: CustomtextService,
     private router: Router,
     private location: Location
   ) {}
@@ -33,6 +39,34 @@ export class UnitDeactivateGuard implements CanDeactivate<UnithostComponent> {
       return of(false);
     }
 
-    return this.tcs.canDeactivateUnit(nextState.url);
+    return this.tcs.state$.pipe(
+      switchMap((state: TestControllerState) => {
+        // The guard is actually called twice: once for 'route-dispatcher' and once for 'status'.
+        // To avoid showing the dialog twice we only intercept the route to status. This prevents
+        // routing to the status component completely making routing back to the unit unnecessary.
+        if (state !== 'RUNNING' || !nextState.url.includes('status')) {
+          return this.tcs.canDeactivateUnit(nextState.url);
+        }
+
+        return this.messageService.showConfirmDialog({
+          title: 'Sicher, dass du den Test beenden möchtest?',
+          content: ''
+        }).pipe(
+          switchMap(result => {
+            if (!result) {
+              return of(false);
+            }
+            this.terminateTest();
+            return of(true);
+          })
+        );
+      })
+    );
+  }
+
+  terminateTest(): void {
+    this.tcs.terminateTest('BOOKLETLOCKEDbyTESTEE', true,
+                           this.tcs.booklet?.config.lock_test_on_termination === 'ON');
+    this.cts.restoreDefault(false);
   }
 }


### PR DESCRIPTION
Instead of using the 'test-status' component, the messaging service with a dialog is used to prompt leaving the unit. This allows for uniform styling by using central components.

The deactive guard of the unit route now displays a prompt when criteria are met, i.e. test-state is still 'running'.

The routing deactivates the route twice. To avoid showing the prompt twice, only one route is used for the dialog. This should avoid going to the test-status route altogether in this case.

The status component template code should be dead but stays in place in case it is somehow reachable another way.