### PR TITLE
[be][bugfix] Normalize call to monitor-groups

### DIFF
--- a/backend/src/controller/SessionController.class.php
+++ b/backend/src/controller/SessionController.class.php
@@ -200,7 +200,7 @@ class SessionController extends Controller {
       $groupMonitors = self::sessionDAO()->getGroupMonitors($personSession);
       $sysChecks = self::sessionDAO()->getSysChecksOfPerson($personSession);
 
-      $accessSet = AccessSet::createFromPersonSession($personSession, $workspaceData, ...$testsOfPerson, ...$groupMonitors, ...$sysChecks);
+      $accessSet = AccessSet::createFromPersonSession($personSession, $workspaceData, ...$testsOfPerson, ...array_values($groupMonitors), ...$sysChecks);
       return $response->withJson($accessSet);
     }
 

--- a/backend/src/dao/SessionDAO.class.php
+++ b/backend/src/dao/SessionDAO.class.php
@@ -551,6 +551,9 @@ class SessionDAO extends DAO {
     return !!$test;
   }
 
+  /**
+   * @return TestData[]
+   */
   public function getTestsOfPerson(PersonSession $personSession): array {
     $testNames = $personSession->getLoginSession()->getLogin()->testNames()[$personSession->getPerson()->getCode() ?? ''];
     if (!count($testNames)) return [];
@@ -637,7 +640,7 @@ class SessionDAO extends DAO {
           )
         ];
       case 'monitor-study':
-        return $this->getGroups($personSession->getLoginSession()->getLogin()->getWorkspaceId());
+        return array_values($this->getGroups($personSession->getLoginSession()->getLogin()->getWorkspaceId()));
     }
   }
 


### PR DESCRIPTION
Controller now only calls Group[] instead of ['group_name' => new Group()]. This prevents error when group_name are mixed with number-only (converted to int) and string.

array_values in SessionDAO is not necessary for this bugfix, but normalizes the return shape of the function

resolves #1369 