### PR TITLE
[fe][gm] Reverse functions on 'Testung beenden'

### DIFF
--- a/frontend/src/app/group-monitor/test-session-manager/test-session-manager.service.ts
+++ b/frontend/src/app/group-monitor/test-session-manager/test-session-manager.service.ts
@@ -4,7 +4,7 @@ import {
 } from 'rxjs';
 import { Sort } from '@angular/material/sort';
 import {
-  delay, filter, flatMap, map, startWith, switchMap, tap
+  delay, filter, mergeMap, map, startWith, switchMap, tap
 } from 'rxjs/operators';
 import { BackendService } from '../backend.service';
 import { BookletService } from '../booklet/booklet.service';
@@ -350,10 +350,10 @@ export class TestSessionManager {
 
     this.filters$.next([]);
 
-    return this.bs.command('terminate', ['lock'], getUnlockedConnectedTestIds())
+    return this.bs.lock(this.groupName, getUnlockedTestIds())
       .pipe(
         delay(1500),
-        flatMap(() => this.bs.lock(this.groupName, getUnlockedTestIds()))
+        mergeMap(() => this.bs.command('terminate', ['lock'], getUnlockedConnectedTestIds()))
       );
   }
 


### PR DESCRIPTION
The new order fixes the issue that upon test termination, the testtaker fetches /session on the starter component and received his other not-currently tests as not-locked. This was because the the termination of the current connected test and redirection to starter happens before the other tests are locked.

Old: Upon entering starter, the backend shows that the other tests are not locked. Is was not an issue with stale state in the frontend.

new: Because all not-connected tests are locked first, before the current test is terminated, the false state (not-locked) stops being shown.

fixes #1129 