### PR TITLE
[be] Change tests:file_id length to the same value as files:id

### DIFF
--- a/scripts/database/patches.d/next.sql
+++ b/scripts/database/patches.d/next.sql
@@ -1,0 +1,3 @@
+ALTER TABLE tests
+  MODIFY file_id VARCHAR(120) NOT NULL COMMENT 'This is the real field mapping to the booklet ID, can have same value more than once. `name` has additional information regarding adaptivity and the pre-configured state of the test.',
+  MODIFY name VARCHAR(250) NOT NULL COMMENT 'This includes the file_id + the symbol "#" for further information for adaptivity and the pre-configured state of the test - the combination of all configs must be unique';


### PR DESCRIPTION
Prior an error occured when trying to create a new entry in tests, for a booklet filename thats longer that 50 characters. This is surprising behaviour, as on upload the limit is 120 characters. On user error, the too long filename should already fail at upload time, not when starting a test.

fixes #1362 