### PR TITLE
[setup] Remove local dependency on helm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,8 @@ push-iqb-registry:
 	$(MAKE) -f $(MK_FILE_DIR)/push.mk -C $(MK_FILE_DIR) $@
 push-helm-chart:
 	$(MAKE) -f $(MK_FILE_DIR)/push.mk -C $(MK_FILE_DIR) $@
+push-helm-chart-production:
+	$(MAKE) -f $(MK_FILE_DIR)/push.mk -C $(MK_FILE_DIR) $@
 
 scan-app:
 	$(MAKE) -f $(MK_FILE_DIR)/scan.mk -C $(MK_FILE_DIR) $@

--- a/scripts/make/push.mk
+++ b/scripts/make/push.mk
@@ -1,6 +1,5 @@
 TC_BASE_DIR := $(shell git rev-parse --show-toplevel)
 TAG := dev
-CHART_VERSION := $(shell helm show chart $(TC_BASE_DIR)/scripts/helm/testcenter | grep -E "^version:" | awk '{print $$2}')
 
 # prevents collisions of make target names with possible file names
 .PHONY: push-dockerhub push-iqb-registry push-helm-chart
@@ -68,8 +67,26 @@ push-iqb-registry: .build
 	docker logout
 
 push-helm-chart:
-	cd $(TC_BASE_DIR)/scripts/helm &&\
-	sed -i.bak "s|^appVersion:.*|appVersion: $(TAG)|" testcenter/Chart.yaml && rm testcenter/Chart.yaml.bak &&\
-	helm package testcenter &&\
-	helm push testcenter-$(CHART_VERSION).tgz oci://registry-1.docker.io/iqbberlin &&\
-	rm testcenter-$(CHART_VERSION).tgz
+	docker run --rm\
+		--volume $(TC_BASE_DIR)/scripts/helm:/work\
+		--volume $(HOME)/.docker:/root/.docker:ro\
+		--workdir /work\
+		--entrypoint sh\
+		alpine/helm:3\
+		-c 'sed -i "s|^appVersion:.*|appVersion: $(TAG)|" testcenter/Chart.yaml &&\
+			CHART_VERSION=$$(helm show chart testcenter | awk "/^version:/ {print \$$2}") &&\
+			helm package testcenter &&\
+			helm push testcenter-$${CHART_VERSION}.tgz oci://registry-1.docker.io/iqbberlin &&\
+			rm testcenter-$${CHART_VERSION}.tgz'
+
+push-helm-chart-production:
+	docker run --rm\
+		--volume $(TC_BASE_DIR)/scripts/helm:/work\
+		--volume $(HOME)/.docker:/root/.docker:ro\
+		--workdir /work\
+		--entrypoint sh\
+		alpine/helm:3\
+		-c 'CHART_VERSION=$$(helm show chart testcenter | awk "/^version:/ {print \$$2}") &&\
+			helm package testcenter &&\
+			helm push testcenter-$${CHART_VERSION}.tgz oci://registry-1.docker.io/iqbberlin &&\
+			rm testcenter-$${CHART_VERSION}.tgz'


### PR DESCRIPTION
Make commands that involve the use of helm, now call a containerized version of helm. No need to locally install helm anymore. Also makes the command usable in the CI.