### PR TITLE
[fe] Fix white status bar on ipad fullscreen

### DIFF
--- a/frontend/src/app/app.component.css
+++ b/frontend/src/app/app.component.css
@@ -2,6 +2,7 @@
   display: flex;
   flex-direction: column;
   height: 100%;
+  background: white;
 }
 
 #main-alert-container {

--- a/frontend/src/theme/index.scss
+++ b/frontend/src/theme/index.scss
@@ -16,6 +16,6 @@ html {
 
 body {
   color-scheme: light;
-  background-color: var(--mat-sys-surface);
+  background-color: var(--mat-sys-primary);
   color: var(--mat-sys-on-surface);
 }


### PR DESCRIPTION
In (mobile) Webkit browsers, the color of the status bar takes on the value of CSS body {background}. When the background is white, the status bar is not readable as white font is on top of white background - appearing like a visual bug with a white strip at the top.

Changing the body color to take theme color, needs the actual background of the app still to be white, hence changing background of tc-root.