### PR TITLE
Show navbar button only on valid values

### DIFF
--- a/frontend/src/app/test-controller/components/test-controller/test-controller.component.html
+++ b/frontend/src/app/test-controller/components/test-controller/test-controller.component.html
@@ -25,7 +25,7 @@
     </tc-navigation-control>
   }
 
-  @if (tcs.booklet?.config?.navbar_forward_button !== 'HIDDEN' && testLoaded) {
+  @if (showGlobalForward && testLoaded) {
     <button matButton="tonal" class="nav-button" data-cy="separate-unit-forward-button"
             [disabled]="!unitNavContext.isForwardAllowed && !pageNavContext.isForwardAllowed"
             (click)="onNavForward()">

--- a/frontend/src/app/test-controller/components/test-controller/test-controller.component.html
+++ b/frontend/src/app/test-controller/components/test-controller/test-controller.component.html
@@ -1,7 +1,7 @@
 <tc-debug-pane *ngIf="debugPane" />
 
 <div class="nav-header flex-row">
-  @if (tcs.booklet?.config?.navbar_backward_button !== 'HIDDEN' && testLoaded) {
+  @if (showGlobalBack && testLoaded) {
     <button matButton="tonal" class="nav-button" data-cy="separate-unit-backward-button"
             [disabled]="!unitNavContext.isBackwardAllowed && !pageNavContext.isBackwardAllowed"
             (click)="onNavBack()">

--- a/frontend/src/app/test-controller/components/test-controller/test-controller.component.ts
+++ b/frontend/src/app/test-controller/components/test-controller/test-controller.component.ts
@@ -124,6 +124,7 @@ export class TestControllerComponent implements OnInit, OnDestroy {
             // set all visual flags from booklet configs
             this.testLoaded = true;
             this.showGlobalBack = this.deriveGlobalBack();
+            this.showGlobalForward = this.deriveGlobalForward();
           } catch (err) {
             if (err instanceof MissingBookletError) { // this happens when loading was aborted.
               // eslint-disable-next-line no-console
@@ -445,6 +446,22 @@ export class TestControllerComponent implements OnInit, OnDestroy {
   protected showGlobalBack = false;
   protected deriveGlobalBack(): boolean {
     const mode = this.tcs.booklet?.config.navbar_backward_button;
+
+    switch (mode) {
+      case 'DYNAMIC':
+      case 'UNITS':
+      case 'PAGES':
+        return true;
+      case 'HIDDEN':
+      case undefined:
+      default:
+        return false;
+    }
+  }
+
+  protected showGlobalForward: boolean = false;
+  protected deriveGlobalForward(): boolean {
+    const mode = this.tcs.booklet?.config.navbar_forward_button;
 
     switch (mode) {
       case 'DYNAMIC':

--- a/frontend/src/app/test-controller/components/test-controller/test-controller.component.ts
+++ b/frontend/src/app/test-controller/components/test-controller/test-controller.component.ts
@@ -121,7 +121,9 @@ export class TestControllerComponent implements OnInit, OnDestroy {
           this.tcs.testId = params.t;
           try {
             await this.tls.loadTest();
+            // set all visual flags from booklet configs
             this.testLoaded = true;
+            this.showGlobalBack = this.deriveGlobalBack();
           } catch (err) {
             if (err instanceof MissingBookletError) { // this happens when loading was aborted.
               // eslint-disable-next-line no-console
@@ -439,6 +441,22 @@ export class TestControllerComponent implements OnInit, OnDestroy {
   }
 
   protected readonly unitNavigationTarget = UnitNavigationTarget;
+
+  protected showGlobalBack = false;
+  protected deriveGlobalBack(): boolean {
+    const mode = this.tcs.booklet?.config.navbar_backward_button;
+
+    switch (mode) {
+      case 'DYNAMIC':
+      case 'UNITS':
+      case 'PAGES':
+        return true;
+      case 'HIDDEN':
+      case undefined:
+      default:
+        return false;
+    }
+  }
 
   protected onNavBack() {
     const mode = this.tcs.booklet?.config?.navbar_backward_button;


### PR DESCRIPTION
Booklet configs 'navbar_backward_button' and 'navbar_forward_button' now only show the button, if the config has a valid value.

resolves #1396 