### PR TITLE
[fe] (fix) Prevent out of bounds page navigation on navbar_backward/f…

### DIFF
--- a/frontend/src/app/test-controller/components/test-controller/test-controller.component.ts
+++ b/frontend/src/app/test-controller/components/test-controller/test-controller.component.ts
@@ -428,10 +428,18 @@ export class TestControllerComponent implements OnInit, OnDestroy {
   }
 
   gotoNextPage(): void {
+    if (this.pageService.isLastPage()) {
+      if (this.tcs.shouldShowConfirmationUI()) this.messageService.showSnackbar('Bereits auf der letzten Seite');
+      return;
+    }
     this.gotoPage(this.pageService.currentPageIndex += 1);
   }
 
   gotoPreviousPage(): void {
+    if (this.pageService.isFirstPage()) {
+      if (this.tcs.shouldShowConfirmationUI()) this.messageService.showSnackbar('Bereits auf der ersten Seite');
+      return;
+    }
     this.gotoPage(this.pageService.currentPageIndex -= 1);
   }
 


### PR DESCRIPTION
…orward_button

When used for page navigation, buttons used to navigate even if already at the first/last page. This is now prevented with additional snackbar

resolves #1399 