### PR TITLE
Add Mago PHP Tooling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,6 +79,8 @@ scan-cache-service:
 scan-db:
 	$(MAKE) -f $(MK_FILE_DIR)/scan.mk -C $(MK_FILE_DIR) $@
 
+mago:
+	$(MAKE) -f $(MK_FILE_DIR)/dev-test.mk -C $(MK_FILE_DIR) $@
 test-backend-unit:
 	$(MAKE) -f $(MK_FILE_DIR)/dev-test.mk -C $(MK_FILE_DIR) $@
 test-backend-unit-coverage:

--- a/backend/composer.json
+++ b/backend/composer.json
@@ -33,6 +33,7 @@
   },
   "require-dev": {
     "amphp/parallel": "2.3.2",
+    "carthage-software/mago": "^1.42.0",
     "mikey179/vfsstream": "1.6.12",
     "phpunit/phpunit":  "10.4.2",
     "mockery/mockery": "1.6.12",

--- a/backend/composer.lock
+++ b/backend/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a5c1d9fab1eb8ff4b1eabe27690f52fd",
+    "content-hash": "14c0aa9884a2f0dd4361148e4f76f327",
     "packages": [
         {
             "name": "altcha-org/altcha",
@@ -1995,6 +1995,65 @@
                 }
             ],
             "time": "2024-08-03T19:31:26+00:00"
+        },
+        {
+            "name": "carthage-software/mago",
+            "version": "1.44.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/carthage-software/mago.git",
+                "reference": "f303d492ebf79bd691009cc5dd0c6907a5ae3bc3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/carthage-software/mago/zipball/f303d492ebf79bd691009cc5dd0c6907a5ae3bc3",
+                "reference": "f303d492ebf79bd691009cc5dd0c6907a5ae3bc3",
+                "shasum": ""
+            },
+            "require": {
+                "php": "~8.1 || ~8.2 || ~8.3 || ~8.4 || ~8.5 || ~8.6"
+            },
+            "suggest": {
+                "ext-curl": "To show binary download progress"
+            },
+            "bin": [
+                "composer/bin/mago"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "composer/src/functions.php",
+                    "composer/src/internal.php"
+                ],
+                "psr-4": {
+                    "Mago\\": "composer/src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT OR Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Saif Eddin Gmati",
+                    "email": "azjezz@carthage.software"
+                }
+            ],
+            "description": "Mago is a toolchain for PHP that aims to provide a set of tools to help developers write better code.",
+            "keywords": [
+                "dev"
+            ],
+            "support": {
+                "issues": "https://github.com/carthage-software/mago/issues",
+                "source": "https://github.com/carthage-software/mago/tree/1.44.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/azjezz",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-07-18T22:50:18+00:00"
         },
         {
             "name": "daverandom/libdns",

--- a/backend/mago.toml
+++ b/backend/mago.toml
@@ -1,0 +1,44 @@
+#:schema https://mago.carthage.software/1.42.0/schema.json
+# Welcome to Mago!
+# For full documentation, see https://mago.carthage.software/1.42.0/en/tools/overview/
+version = "1"
+php-version = "8.3.12"
+
+[source]
+workspace = "."
+paths = []
+includes = ["vendor"]
+excludes = []
+
+[source.glob]
+literal-separator = true
+
+[formatter]
+preset = "default"
+
+[linter]
+integrations = ["phpunit"]
+
+[linter.rules]
+ambiguous-function-call = { enabled = false }
+literal-named-argument = { enabled = false }
+halstead = { effort-threshold = 7000 }
+
+[analyzer]
+plugins = []
+find-unused-definitions = false
+find-unused-expressions = false
+analyze-dead-code = false
+memoize-properties = true
+allow-possibly-undefined-array-keys = true
+check-throws = false
+unchecked-exceptions = ["Error", "LogicException"]
+unchecked-exception-classes = []
+check-missing-override = false
+find-unused-parameters = false
+strict-list-index-checks = false
+strict-array-index-existence = false
+allow-array-truthy-operand = false
+no-boolean-literal-comparison = false
+check-missing-type-hints = false
+register-super-globals = true

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -97,6 +97,7 @@ services:
       - ./backend/routes.php:/var/www/testcenter/backend/routes.php
       - ./backend/src:/var/www/testcenter/backend/src
       - ./backend/test:/var/www/testcenter/backend/test
+      - ./backend/mago.toml:/var/www/testcenter/backend/mago.toml:ro
       - ./definitions:/var/www/testcenter/definitions
       - ./docs/dist:/docs/dist
       - ./package.json:/var/www/testcenter/package.json

--- a/scripts/make/dev-test.mk
+++ b/scripts/make/dev-test.mk
@@ -1,5 +1,14 @@
 TC_BASE_DIR := $(shell git rev-parse --show-toplevel)
+MAGO_VERSION := ${shell jq -r '."packages-dev"[] | select(.name == "carthage-software/mago") | .version' $(TC_BASE_DIR)/backend/composer.lock}
 target ?= .
+args ?= --help
+
+test-backend-static-analysis:
+	docker run --rm\
+			--user $(shell id -u):$(shell id -g)\
+			--volume $(TC_BASE_DIR)/backend:/app\
+			--workdir /app\
+		ghcr.io/carthage-software/mago:$(MAGO_VERSION) $(args)
 
 test-backend-unit:
 	cd $(TC_BASE_DIR) &&\


### PR DESCRIPTION
@rhenck zur Info

Mago ist eine moderne, Toolset für PHP, das eine weitaus bessere Performance hat als klassische Tools und auf einen Schlag mehrere Tools anbietet.

Beinhaltet derzeit sind Linter, Analyzer, Architektur-guard und Formatter, und ersetzt dadurch phpstan, php-cs-fixer, php-codesniffer, deptrac. 

Die gängigen Tools sind zwar Featurereicher (zB umfangreichere Linter Einstellungen oder komplexe checks auf PHP arrays), aber für unser Projekt ist das in diesem Moment nicht notwendig, da wir erstmal bei null anfangen und zB beim Linter erstmal auf eine vernünftige Basis refactoren müssen. 

Wenn sich später herausstellt, dass Mago nicht ausreichend ist, kann man meiner Meinung nach immer noch auf die schwergewichtigeren Libraries wechseln.