### PR TITLE
[be] Fix session admin test

### DIFF
--- a/backend/test/unit/controller/SessionControllerTest.php
+++ b/backend/test/unit/controller/SessionControllerTest.php
@@ -342,7 +342,7 @@ final class SessionControllerTest extends TestCase {
     ]);
 
     $response = SessionController::putSessionAdmin(
-      RequestCreator::create('PUT', '/session/admin', '{"name":"super"}'),
+      RequestCreator::create('PUT', '/session/admin', '{"name":"super", "password":""}'),
       ResponseCreator::createEmpty()
     );
 


### PR DESCRIPTION
Schau dir das mal bitte an. Ich verstehe nicht, warum das kaputt ist. Ist durch den brute-force-PR reingekommen, der hatte das password auf leer gesetzt und du hast es danach wieder zurueckgesetzt. Anscheinend ist es aber noetig, das auf leer zu haben.