### PR TITLE
Test leave

### DIFF
--- a/frontend/src/app/shared/components/header/header.component.ts
+++ b/frontend/src/app/shared/components/header/header.component.ts
@@ -50,7 +50,7 @@ export class HeaderComponent implements OnDestroy {
     ).subscribe(() => {
       this.isLoginRoute = router.url.includes('code-input') ||
                                    router.url.includes('login');
-      this.logoLink = this.isLoginRoute ? ['/r/login'] : ['/r'];
+      this.logoLink = this.isLoginRoute ? ['/r/login'] : ['/r/starter'];
     });
 
     assetService.assetSlots$.subscribe(() => {

--- a/frontend/src/app/test-controller/components/test-status/test-status.component.html
+++ b/frontend/src/app/test-controller/components/test-status/test-status.component.html
@@ -1,25 +1,4 @@
 <div [ngSwitch]="(tcs.state$ | async)" class="flex-row-wrap" [style.justify-content]="'center'">
-  <mat-card appearance="raised" class="mat-card-box" *ngSwitchDefault>
-    <mat-card-header>
-      <mat-card-title>{{ tcs.booklet?.metadata?.label }}</mat-card-title>
-    </mat-card-header>
-    <mat-card-content data-cy="card-end-resume-test">
-      <p><b>Angemeldet als "{{loginName}}"</b></p>
-      <p><b>{{tcs.testMode.modeLabel}}</b></p>
-      <p *ngIf="(tcs.state$ | async) === 'RUNNING'" style="color: chocolate">
-        <b>Der Test ist aktiv.</b>
-      </p>
-    </mat-card-content>
-    <mat-card-actions [style.justify-content]="'space-between'">
-      <button mat-raised-button data-cy="resumeTest-1" (click)="continueTest()">
-        {{ 'Test fortsetzen'  | customtext:'login_testResumeButtonLabel' | async}}
-      </button>
-      <button mat-raised-button data-cy="endTest-1" (click)="terminateTest()">
-        {{ 'Test beenden'  | customtext:'login_testEndButtonLabel' | async}}
-      </button>
-    </mat-card-actions>
-  </mat-card>
-
   <mat-card appearance="raised" class="mat-card-box" *ngSwitchCase="'PAUSED'">
     <mat-card-header>
       <mat-card-title>{{ tcs.booklet?.metadata?.label }}</mat-card-title>

--- a/frontend/src/app/test-controller/components/test-status/test-status.component.ts
+++ b/frontend/src/app/test-controller/components/test-status/test-status.component.ts
@@ -1,9 +1,8 @@
 import { Component, OnInit } from '@angular/core';
 import {
-  AsyncPipe, NgIf, NgSwitch, NgSwitchCase, NgSwitchDefault
+  AsyncPipe, NgSwitch, NgSwitchCase
 } from '@angular/common';
 import { MatCardModule } from '@angular/material/card';
-import { MatButton } from '@angular/material/button';
 import {
   AlertComponent, CustomtextPipe, CustomtextService, MainDataService
 } from '@shared/shared.module';
@@ -17,9 +16,6 @@ import { TestControllerService } from '@app/test-controller';
     NgSwitch,
     MatCardModule,
     AsyncPipe,
-    NgSwitchDefault,
-    NgIf,
-    MatButton,
     CustomtextPipe,
     NgSwitchCase,
     AlertComponent,
@@ -33,8 +29,7 @@ export class TestStatusComponent implements OnInit {
 
   constructor(
     public tcs: TestControllerService,
-    public mainDataService: MainDataService,
-    private cts: CustomtextService) { }
+    public mainDataService: MainDataService) { }
 
   ngOnInit(): void {
     setTimeout(() => {
@@ -47,14 +42,5 @@ export class TestStatusComponent implements OnInit {
 
   reloadPage(error: AppError): void {
     this.mainDataService.reloadPage(error.type === 'session');
-  }
-
-  terminateTest(): void {
-    this.tcs.terminateTest('BOOKLETLOCKEDbyTESTEE', true, this.tcs.booklet?.config.lock_test_on_termination === 'ON');
-    this.cts.restoreDefault(false);
-  }
-
-  continueTest() {
-    this.tcs.setUnitNavigationRequest(this.tcs.currentUnitSequenceId.toString(10));
   }
 }

--- a/frontend/src/app/test-controller/routing/test-controller-deactivate.guard.ts
+++ b/frontend/src/app/test-controller/routing/test-controller-deactivate.guard.ts
@@ -1,13 +1,18 @@
 import { Injectable } from '@angular/core';
 import { CanDeactivate, RedirectCommand, Router } from '@angular/router';
+import { firstValueFrom } from 'rxjs';
+import { MessageService } from '@shared/services/message.service';
 import { TestControllerState, UnitNavigationTarget } from '../interfaces/test-controller.interfaces';
-import { TestControllerService } from '../services/test-controller.service';
 import { TestControllerComponent } from '../components/test-controller/test-controller.component';
+import { TestControllerService } from '../services/test-controller.service';
+import { CustomtextService } from '@shared/services/customtext/customtext.service';
 
 @Injectable()
 export class TestControllerDeactivateGuard implements CanDeactivate<TestControllerComponent> {
   constructor(
     private tcs: TestControllerService,
+    private messageService: MessageService,
+    private cts: CustomtextService,
     private router: Router
   ) {
   }
@@ -25,13 +30,25 @@ export class TestControllerDeactivateGuard implements CanDeactivate<TestControll
             { skipLocationChange: true, state: { force: false } }
           );
         }
-        await this.tcs.closeAllBuffers(`setUnitNavigationRequest(${UnitNavigationTarget.PAUSE} NEXT`);
-        return new RedirectCommand(
-          this.router.parseUrl(`/t/${this.tcs.testId}/status`),
-          { skipLocationChange: true, state: { force: false } }
+        const isLeaveConfirmed = await firstValueFrom(
+          this.messageService.showConfirmDialog({
+            title: 'Sicher, dass du den Test beenden möchtest?',
+            content: ''
+          })
         );
+        if (isLeaveConfirmed) {
+          await this.tcs.closeAllBuffers(`setUnitNavigationRequest(${UnitNavigationTarget.PAUSE} NEXT`);
+          this.terminateTest();
+        }
+        return isLeaveConfirmed;
       }
     }
     return true;
+  }
+
+  terminateTest(): void {
+    this.tcs.terminateTest(
+      'BOOKLETLOCKEDbyTESTEE', true, this.tcs.booklet?.config.lock_test_on_termination === 'ON');
+    this.cts.restoreDefault(false);
   }
 }

--- a/frontend/src/app/test-controller/routing/test-controller-deactivate.guard.ts
+++ b/frontend/src/app/test-controller/routing/test-controller-deactivate.guard.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@angular/core';
-import { CanDeactivate, RedirectCommand, Router } from '@angular/router';
+import { CanDeactivate, Router } from '@angular/router';
 import { firstValueFrom } from 'rxjs';
+import { AppError } from '@app/app.interfaces';
 import { MessageService } from '@shared/services/message.service';
 import { TestControllerState, UnitNavigationTarget } from '../interfaces/test-controller.interfaces';
 import { TestControllerComponent } from '../components/test-controller/test-controller.component';
@@ -25,10 +26,10 @@ export class TestControllerDeactivateGuard implements CanDeactivate<TestControll
         // this whole inner block mimics setUnitNavigationRequest(PAUSE), without manually triggering router.navigate()
         // in order to correctly return a redirect, instead of hacking (router.navigate + return false)
         if (!this.tcs.booklet) {
-          return new RedirectCommand(
-            this.router.parseUrl(`/t/${this.tcs.testId}/status`),
-            { skipLocationChange: true, state: { force: false } }
-          );
+          throw new AppError({
+            label: 'Kein Booklet gefunden.',
+            description: ''
+          });
         }
         const isLeaveConfirmed = await firstValueFrom(
           this.messageService.showConfirmDialog({

--- a/frontend/src/app/test-controller/services/test-controller.service.ts
+++ b/frontend/src/app/test-controller/services/test-controller.service.ts
@@ -551,7 +551,10 @@ export class TestControllerService {
 
   async setUnitNavigationRequest(navString: string, force = false): Promise<boolean> {
     if (!this.booklet) {
-      return this.router.navigate([`/t/${this.testId}/status`], { skipLocationChange: true, state: { force } });
+      throw new AppError({
+        label: 'Kein Booklet gefunden.',
+        description: ''
+      });
     }
     let navigation: NavigationState;
     switch (navString) {


### PR DESCRIPTION
Hier die besprochenen Aenderungen am Verhalten beim Verlassen eines Tests. Es wird ein Dialog benutzt anstatt zur status-component zu navigieren und der Header linkt nicht mehr auf das generische /r.

Sollte dir eigentlich alles bekannt sein, aber schau gerne nochmal drauf.